### PR TITLE
Add option to exclude columns from subset

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,15 +1,11 @@
-* Test primary key comes AFTER a column that has been excluded -- column Ordinal should take into account excluded columns
+* Support tables without primary keys
 * Test the school DB in an automated test
 * Test the akka-streams versions of things alongside the singleThreadedDebugMode
 * Try to support MySQL, SQL Server, and Oracle
-* Docker: address error message during postgresql data loading:
-  LOG:  checkpoints are occurring too frequently (5 seconds apart)
-  HINT:  Consider increasing the configuration parameter "max_wal_size".
 * Try to find memory/performance bottlenecks by profiling against a huge database
 * Add some sort of way to shut down or otherwise finish the akka-streams version instead of hanging forever (otherwise how can we do automated tests of it?)
-* Add retry logic to DB Queries in case of failure
+* Add retry logic to DB Queries in case of failure, e.g. due to temporary network problem
 * Allow for not fetching children of baseQuery (on a per-baseQuery basis)
-* Support tables without primary keys
 * Investigate whether optimization is possible via changing AnyRef to Any and then using primitive Ints instead of Integer for PK storage, etc.
 * Consider better support for uncommon data types such as money, enums, arrays of enums, etc
   -- Could the enum case be addressed via type casting in a way that does not cause other bugs or harm performance?

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,6 @@
-* Test more different data types / foreign key types
+* Test custom postgres data types -- add feature to exclude columns
+* Test the school DB in an automated test
+* Test the akka-streams versions of things alongside the singleThreadedDebugMode
 * Try to support MySQL, SQL Server, and Oracle
 * Docker: address error message during postgresql data loading:
   LOG:  checkpoints are occurring too frequently (5 seconds apart)
@@ -7,3 +9,5 @@
 * Add some sort of way to shut down or otherwise finish the akka-streams version instead of hanging forever (otherwise how can we do automated tests of it?)
 * Add retry logic to DB Queries in case of failure
 * Allow for not fetching children of baseQuery (on a per-baseQuery basis)
+* Support tables without primary keys
+* Investigate whether optimization is possible via changing AnyRef to Any and then using primitive Ints instead of Integer for PK storage, etc.

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,3 @@
-* Test custom postgres data types -- add feature to exclude columns
 * Test the school DB in an automated test
 * Test the akka-streams versions of things alongside the singleThreadedDebugMode
 * Try to support MySQL, SQL Server, and Oracle
@@ -11,3 +10,5 @@
 * Allow for not fetching children of baseQuery (on a per-baseQuery basis)
 * Support tables without primary keys
 * Investigate whether optimization is possible via changing AnyRef to Any and then using primitive Ints instead of Integer for PK storage, etc.
+* Consider better support for uncommon data types such as money, enums, arrays of enums, etc
+  -- Could the enum case be addressed via type casting in a way that does not cause other bugs or harm performance?

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,3 +1,4 @@
+* Test primary key comes AFTER a column that has been excluded -- column Ordinal should take into account excluded columns
 * Test the school DB in an automated test
 * Test the akka-streams versions of things alongside the singleThreadedDebugMode
 * Try to support MySQL, SQL Server, and Oracle

--- a/src/main/scala/trw/dbsubsetter/config/Config.scala
+++ b/src/main/scala/trw/dbsubsetter/config/Config.scala
@@ -1,12 +1,13 @@
 package trw.dbsubsetter.config
 
-import trw.dbsubsetter.db.{SchemaName, TableName, WhereClause}
+import trw.dbsubsetter.db.{ColumnName, SchemaName, TableName, WhereClause}
 
 case class Config(schemas: Seq[String] = Seq.empty,
                   originDbConnectionString: String = "",
                   targetDbConnectionString: String = "",
                   baseQueries: List[((SchemaName, TableName), WhereClause)] = List.empty,
-                  cmdLineForeignKeys: List[CommandLineStandardForeignKey] = List.empty,
+                  cmdLineForeignKeys: List[CmdLineForeignKey] = List.empty,
+                  excludeColumns: Map[(SchemaName, TableName), Set[ColumnName]] = Map.empty.withDefaultValue(Set.empty),
                   originDbParallelism: Int = 1,
                   targetDbParallelism: Int = 1,
                   isSingleThreadedDebugMode: Boolean = false)

--- a/src/main/scala/trw/dbsubsetter/db/OriginDbAccess.scala
+++ b/src/main/scala/trw/dbsubsetter/db/OriginDbAccess.scala
@@ -31,11 +31,8 @@ class OriginDbAccess(connStr: String, sch: SchemaInfo) {
   }
 
   private def jdbcResultToRows(res: ResultSet, table: Table): Vector[Row] = {
-    // Could we avoid using ArrayBuffer by knowing up front how many rows were fetched from DB?
     val cols = sch.colsByTable(table).size
-
     val rows = ArrayBuffer.empty[Row]
-
     while (res.next()) {
       val row = new Array[AnyRef](cols)
       (1 to cols).foreach(i => row(i - 1) = res.getObject(i))

--- a/src/main/scala/trw/dbsubsetter/db/OriginDbAccess.scala
+++ b/src/main/scala/trw/dbsubsetter/db/OriginDbAccess.scala
@@ -31,7 +31,7 @@ class OriginDbAccess(connStr: String, sch: SchemaInfo) {
   }
 
   private def jdbcResultToRows(res: ResultSet, table: Table): Vector[Row] = {
-    val cols = sch.colsByTable(table).size
+    val cols = sch.colsByTableOrdered(table).size
     val rows = ArrayBuffer.empty[Row]
     while (res.next()) {
       val row = new Array[AnyRef](cols)

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -29,12 +29,14 @@ object SchemaInfoRetrieval {
 
       val columnsJdbcResultSet = ddl.getColumns(null, schema, null, null)
       while (columnsJdbcResultSet.next()) {
-        columnsQueryResult += ColumnQueryRow(
-          columnsJdbcResultSet.getString("TABLE_SCHEM"),
-          columnsJdbcResultSet.getString("TABLE_NAME"),
-          columnsJdbcResultSet.getString("COLUMN_NAME"),
-          columnsJdbcResultSet.getInt("ORDINAL_POSITION")
-        )
+        val schema = columnsJdbcResultSet.getString("TABLE_SCHEM")
+        val table = columnsJdbcResultSet.getString("TABLE_NAME")
+        val columnName = columnsJdbcResultSet.getString("COLUMN_NAME")
+        val ordinalPosition = columnsJdbcResultSet.getInt("ORDINAL_POSITION")
+
+        if (!config.excludeColumns((schema, table)).contains(columnName)) {
+          columnsQueryResult += ColumnQueryRow(schema, table, columnName, ordinalPosition)
+        }
       }
 
       // Args: catalog, schema, table

--- a/src/main/scala/trw/dbsubsetter/db/Sql.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Sql.scala
@@ -15,7 +15,7 @@ object Sql {
         case ForeignKey(_, _, _, None) =>
           makeQueryString(table, whereClauseColumnParts.mkString(" and "), sch)
         case ForeignKey(fromCols, toCols, _, Some(additionalWhereClause)) =>
-          val selectCols = sch.colsByTable(table).map(_.fullyQualifiedName).mkString(", ")
+          val selectCols = sch.colsByTableOrdered(table).map(_.fullyQualifiedName).mkString(", ")
           val whereClause = (whereClauseColumnParts :+ additionalWhereClause).mkString(" and ")
           val otherTable = if (table == fk.toTable) fk.fromTable else fk.toTable
           val joinClause = fromCols.zip(toCols).map { case (f, t) => s"${f.fullyQualifiedName} = ${t.fullyQualifiedName}" }.mkString(" and ")
@@ -31,7 +31,7 @@ object Sql {
 
   def preparedInsertStatementStrings(sch: SchemaInfo): Map[Table, SqlQuery] = {
     sch.tablesByName.map { case (tableName, table) =>
-      val cols = sch.colsByTable(table)
+      val cols = sch.colsByTableOrdered(table)
       val sqlString =
         s"""insert into ${table.fullyQualifiedName}
            |${cols.map(_.quotedName).mkString("(", ",", ")")}
@@ -41,7 +41,7 @@ object Sql {
   }
 
   def makeQueryString(table: Table, whereClause: WhereClause, sch: SchemaInfo): SqlQuery = {
-    val selectCols = sch.colsByTable(table).map(_.fullyQualifiedName).mkString(", ")
+    val selectCols = sch.colsByTableOrdered(table).map(_.fullyQualifiedName).mkString(", ")
     s"""select $selectCols
          | from ${table.fullyQualifiedName}
          | where $whereClause

--- a/src/main/scala/trw/dbsubsetter/db/TargetDbAccess.scala
+++ b/src/main/scala/trw/dbsubsetter/db/TargetDbAccess.scala
@@ -10,7 +10,7 @@ class TargetDbAccess(connStr: String, sch: SchemaInfo) {
 
   def insertRows(table: Table, rows: Vector[Row]): Int = {
     val stmt = statements(table)
-    val cols = sch.colsByTable(table).size
+    val cols = sch.colsByTableOrdered(table).size
 
     rows.foreach { row =>
       (1 to cols).foreach(i => stmt.setObject(i, row(i - 1)))

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -15,7 +15,7 @@ package object db {
   type SqlTemplates = Map[(ForeignKey, Table), SqlQuery]
 
   case class SchemaInfo(tablesByName: Map[(SchemaName, TableName), Table],
-                        colsByTable: Map[Table, Vector[Column]],
+                        colsByTableOrdered: Map[Table, Vector[Column]],
                         pkOrdinalsByTable: Map[Table, Vector[Int]],
                         fks: Set[ForeignKey],
                         fksFromTable: Map[Table, Set[ForeignKey]],

--- a/src/main/scala/trw/dbsubsetter/workflow/BaseQueries.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/BaseQueries.scala
@@ -8,7 +8,7 @@ object BaseQueries {
   def get(config: Config, sch: SchemaInfo): Iterable[SqlStrQuery] = {
     config.baseQueries.map { case ((schemaName, tableName), whereClause) =>
       val table = sch.tablesByName((schemaName, tableName))
-      val sqlString = Sql.makeQueryString(table, whereClause)
+      val sqlString = Sql.makeQueryString(table, whereClause, sch)
       SqlStrQuery(table, sqlString)
     }
   }

--- a/src/main/scala/trw/dbsubsetter/workflow/NewFkTaskWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/NewFkTaskWorkflow.scala
@@ -27,7 +27,7 @@ object NewFkTaskWorkflow {
   }
 
   private def getForeignKeyValues(fk: ForeignKey, cols: Vector[Column], rows: Vector[Row]): Vector[AnyRef] = {
-    val ordinalPositions = cols.map(_.ordinalPosition - 1)
+    val ordinalPositions = cols.map(_.ordinalPosition)
     if (fk.isSingleCol) {
       val ordinalPosition = ordinalPositions.head
       rows.map(row => row(ordinalPosition))

--- a/src/test/scala/e2e/PgDataTypesTest.scala
+++ b/src/test/scala/e2e/PgDataTypesTest.scala
@@ -1,0 +1,56 @@
+package e2e
+
+import java.sql.{Connection, DriverManager}
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+import trw.dbsubsetter.Application
+
+import scala.sys.process._
+
+class PgDataTypesTest extends FunSuite with BeforeAndAfterAll {
+  val targetConnString = "jdbc:postgresql://localhost:5501/pg_data_types_target?user=postgres"
+  var targetConn: Connection = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    "./util/pg_data_types/reset_origin_db.sh".!!
+    "./util/pg_data_types/reset_target_db.sh".!!
+
+    val args = Array(
+      "--schemas", "public",
+      "--originDbConnStr", "jdbc:postgresql://localhost:5500/pg_data_types_origin?user=postgres",
+      "--targetDbConnStr", targetConnString,
+      "--baseQuery", "public.arrays_table=true",
+      "--baseQuery", "public.binary_table=true",
+      //      "--baseQuery", "public.bit_string_table=true", // not working
+      //      "--baseQuery", "public.enum_table=true", // not working
+      "--baseQuery", "public.geometric_table=true",
+      "--baseQuery", "public.hstore_table=true",
+      "--baseQuery", "public.json_table=true",
+      //      "--baseQuery", "public.money_table=true", // not working
+      "--baseQuery", "public.network_address_table=true",
+      "--baseQuery", "public.range_table=true",
+      "--baseQuery", "public.text_search_table=true",
+      "--baseQuery", "public.times_table=true",
+      "--baseQuery", "public.xml_table=true",
+      "--originDbParallelism", "1",
+      "--targetDbParallelism", "1",
+      "--singleThreadedDebugMode"
+    )
+    Application.main(args)
+
+    "./util/pg_data_types/post_subset_target.sh".!!
+
+    targetConn = DriverManager.getConnection(targetConnString)
+    targetConn.setReadOnly(true)
+  }
+
+  override protected def afterAll(): Unit = {
+    super.afterAll()
+    targetConn.close()
+  }
+
+  test("No error was thrown during subsetting") {
+    // Do nothing, just make sure an exception wasn't thrown
+  }
+}

--- a/src/test/scala/e2e/PgDataTypesTest.scala
+++ b/src/test/scala/e2e/PgDataTypesTest.scala
@@ -22,17 +22,21 @@ class PgDataTypesTest extends FunSuite with BeforeAndAfterAll {
       "--targetDbConnStr", targetConnString,
       "--baseQuery", "public.arrays_table=true",
       "--baseQuery", "public.binary_table=true",
-      //      "--baseQuery", "public.bit_string_table=true", // not working
-      //      "--baseQuery", "public.enum_table=true", // not working
+      "--baseQuery", "public.bit_string_table=true",
+      "--baseQuery", "public.enum_table=true",
       "--baseQuery", "public.geometric_table=true",
       "--baseQuery", "public.hstore_table=true",
       "--baseQuery", "public.json_table=true",
-      //      "--baseQuery", "public.money_table=true", // not working
+      "--baseQuery", "public.money_table=true",
       "--baseQuery", "public.network_address_table=true",
       "--baseQuery", "public.range_table=true",
       "--baseQuery", "public.text_search_table=true",
       "--baseQuery", "public.times_table=true",
       "--baseQuery", "public.xml_table=true",
+      // The following data types are unfortunately not working yet
+      "--excludeColumns", "public.money_table(money)",
+      "--excludeColumns", "public.enum_table(enum)",
+      "--excludeColumns", "public.bit_string_table(bit_1, bit_5)",
       "--originDbParallelism", "1",
       "--targetDbParallelism", "1",
       "--singleThreadedDebugMode"

--- a/util/pg_data_types/1_pre_data.sql
+++ b/util/pg_data_types/1_pre_data.sql
@@ -53,11 +53,12 @@ CREATE TABLE network_address_table (
 );
 
 CREATE TABLE bit_string_table (
-  id                    SERIAL PRIMARY KEY,
   bit_1                 BIT,
   bit_5                 BIT(5),
   bit_varying_unlimited BIT VARYING,
-  bit_varying_10        BIT VARYING(10)
+  bit_varying_10        BIT VARYING(10),
+  -- edge case: primary key after a column that will be configured as excluded
+  id                    SERIAL PRIMARY KEY
 );
 
 CREATE TABLE text_search_table (

--- a/util/pg_data_types/1_pre_data.sql
+++ b/util/pg_data_types/1_pre_data.sql
@@ -1,0 +1,94 @@
+CREATE TABLE arrays_table (
+  id            SERIAL PRIMARY KEY,
+  string_array  VARCHAR [],
+  int_array     INT [],
+  decimal_array DECIMAL [],
+  nested_array  VARCHAR [] []
+);
+-- Still need array of an enum and array of json, array of jsonb, etc.
+
+
+CREATE TABLE money_table (
+  id    SERIAL PRIMARY KEY,
+  money MONEY
+);
+
+CREATE TABLE binary_table (
+  id    SERIAL PRIMARY KEY,
+  bytea BYTEA
+);
+
+CREATE TABLE times_table (
+  id                          SERIAL PRIMARY KEY,
+  timestamp_without_time_zone TIMESTAMP WITHOUT TIME ZONE,
+  timestamp_with_time_zone    TIMESTAMP WITH TIME ZONE,
+  date                        DATE,
+  time_without_time_zone      TIME WITHOUT TIME ZONE,
+  time_with_time_zone         TIME WITH TIME ZONE,
+  interval                    INTERVAL
+);
+
+CREATE TYPE MOOD AS ENUM ('sad', 'ok', 'happy');
+CREATE TABLE enum_table (
+  id   SERIAL PRIMARY KEY,
+  enum MOOD
+);
+
+CREATE TABLE geometric_table (
+  id      SERIAL PRIMARY KEY,
+  point   POINT,
+  line    LINE,
+  lseg    LSEG,
+  box     BOX,
+  path    PATH,
+  polygon POLYGON,
+  circle  CIRCLE
+);
+
+CREATE TABLE network_address_table (
+  id      SERIAL PRIMARY KEY,
+  cidr    CIDR,
+  inet    INET,
+  macaddr MACADDR
+);
+
+CREATE TABLE bit_string_table (
+  id                    SERIAL PRIMARY KEY,
+  bit_1                 BIT,
+  bit_5                 BIT(5),
+  bit_varying_unlimited BIT VARYING,
+  bit_varying_10        BIT VARYING(10)
+);
+
+CREATE TABLE text_search_table (
+  id       SERIAL PRIMARY KEY,
+  tsvector TSVECTOR,
+  tsquery  TSQUERY
+);
+
+CREATE TABLE xml_table (
+  id  SERIAL PRIMARY KEY,
+  xml XML
+);
+
+CREATE TABLE json_table (
+  id    SERIAL PRIMARY KEY,
+  json  JSON,
+  jsonb JSONB
+);
+
+CREATE EXTENSION hstore;
+CREATE TABLE hstore_table (
+  id     SERIAL PRIMARY KEY,
+  hstore HSTORE
+);
+
+CREATE TABLE range_table (
+  id        SERIAL PRIMARY KEY,
+  int4range INT4RANGE,
+  int8range INT8RANGE,
+  numrange  NUMRANGE,
+  tsrange   TSRANGE,
+  tstzrange TSTZRANGE,
+  daterange DATERANGE
+)

--- a/util/pg_data_types/2_data.sql
+++ b/util/pg_data_types/2_data.sql
@@ -1,0 +1,83 @@
+INSERT INTO arrays_table (id, string_array, int_array, decimal_array, nested_array) VALUES
+  (1, ARRAY ['str_one', 'str_two', 'str_three', 'str_four'], NULL, NULL, NULL),
+  (2, NULL, ARRAY [1, 2, 3, 4, 5], NULL, NULL),
+  (3, NULL, NULL, ARRAY [2.87, 5893.232345, 1234.90, 9], NULL),
+  (4, NULL, NULL, NULL,
+   ARRAY [ARRAY ['one_one', 'one_two'], ARRAY ['two_one', 'two_two'], ARRAY ['three_one', 'three_two']]),
+  (5, ARRAY ['one', 'two'], ARRAY [1, 2], ARRAY [1.1, 2.2], ARRAY [ARRAY ['one'], ARRAY ['two']]),
+  (6, '{}', '{}', '{}', '{}');
+
+INSERT INTO money_table (id, money) VALUES
+  (1, '$1,000.00'),
+  (2, NULL);
+
+INSERT INTO binary_table (id, bytea) VALUES
+  (1, E'\\000' :: BYTEA),
+  (2, E'\'' :: BYTEA),
+  (3, E'\\\\' :: BYTEA),
+  (4, E'\\001' :: BYTEA),
+  (5, NULL);
+
+INSERT INTO times_table
+(id, timestamp_without_time_zone, timestamp_with_time_zone, date, time_without_time_zone, time_with_time_zone, interval)
+VALUES
+  (1, '2017-11-18 13:26:07.888767', '2017-11-18 18:26:51.934744 +01:00', '1999-01-01', '13:28:00 ', '12:27:46 -06:00',
+   '12 years');
+
+INSERT INTO enum_table (id, enum)
+VALUES
+  (1, 'sad'),
+  (2, 'happy'),
+  (3, 'ok'),
+  (4, NULL);
+
+INSERT INTO geometric_table (id, point, line, lseg, box, path, polygon, circle)
+VALUES
+  (1, '3, 9', '{3, 7, 9}', '[(1, 2), (3, 4)]', '((1, 1), (5, 5))', '[(1,1),(2,2),(3,3),(4,4)]',
+   '((1,1),(2,2),(3,3),(4,4),(5,5))', '<(78,91), 3>'),
+  (2, NULL, NULL, NULL, NULL, '((1,1),(2,2),(3,3),(4,4))', NULL, NULL),
+  (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL);
+
+INSERT INTO network_address_table (id, cidr, inet, macaddr)
+VALUES
+  (1, '192.168.100.128/25', '2001:4f8:3:ba::/64', '08:00:2b:01:02:03'),
+  (2, NULL, NULL, NULL);
+
+INSERT INTO bit_string_table (id, bit_1, bit_5, bit_varying_unlimited, bit_varying_10)
+VALUES
+  (1, '1', '00100', '100101101101010111111', '01'),
+  (2, '0', '00101', '', '1111111111'),
+  (3, NULL, NULL, NULL, NULL);
+
+INSERT INTO text_search_table (id, tsvector, tsquery)
+VALUES
+  (1, 'a cat sat on a mat and ate a rat', NULL),
+  (2, NULL, 'cat & rat');
+
+INSERT INTO xml_table (id, xml)
+VALUES
+  (1, XMLPARSE(DOCUMENT '<?xml version="1.0"?><book><title>Manual</title><chapter>...</chapter></book>')),
+  (2, XMLPARSE(CONTENT 'abc<foo>bar</foo><bar>foo</bar>')),
+  (3, NULL);
+
+INSERT INTO json_table (id, json, jsonb)
+VALUES
+  (1, '{"bar": "baz", "balance": 7.77, "active":false}', '{"bar": "baz", "balance": 7.77, "active":false}'),
+  (2, NULL, NULL);
+
+INSERT INTO hstore_table (id, hstore)
+VALUES
+  (1, 'a=>b, b=>1, c=>NULL'),
+  (2, NULL);
+
+INSERT INTO range_table (id, int4range, int8range, numrange, tsrange, tstzrange, daterange)
+VALUES
+  (1, '[1, 4]', '[1, 4]', '[2.3, 7.9]', '[2017-11-18 15:01:58.989987, 2018-11-12 15:01:58.989999]',
+   '[2011-11-18 15:01:58.989988 -04:00, 2022-11-11 15:01:58.989991 +01:00]', '[2011-09-25, 2012-01-01]'),
+  (2, '(1, 4)', '(1, 4)', '(2.3, 7.9)', '(2017-11-18 15:01:58.989987, 2018-11-12 15:01:58.989999)',
+   '(2011-11-18 15:01:58.989988 -04:00, 2022-11-11 15:01:58.989991 +01:00)', '(2011-09-25, 2012-01-01)'),
+  (3, '(1, 4]', '(1, 4]', '(2.3, 7.9]', '(2017-11-18 15:01:58.989987, 2018-11-12 15:01:58.989999]',
+   '(2011-11-18 15:01:58.989988 -04:00, 2022-11-11 15:01:58.989991 +01:00]', '(2011-09-25, 2012-01-01]'),
+  (4, '[1, 4)', '[1, 4)', '[2.3, 7.9)', '[2017-11-18 15:01:58.989987, 2018-11-12 15:01:58.989999)',
+   '[2011-11-18 15:01:58.989988 -04:00, 2022-11-11 15:01:58.989991 +01:00)', '[2011-09-25, 2012-01-01)'),
+  (5, NULL, NULL, NULL, NULL, NULL, NULL);

--- a/util/pg_data_types/3_post_data.sql
+++ b/util/pg_data_types/3_post_data.sql
@@ -1,0 +1,1 @@
+-- Do nothing

--- a/util/pg_data_types/post_subset_target.sh
+++ b/util/pg_data_types/post_subset_target.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+pg_dump -h localhost -p 5500 -U postgres --section=post-data pg_data_types_origin | psql -h localhost -p 5501 -U postgres pg_data_types_target -v ON_ERROR_STOP=1

--- a/util/pg_data_types/reset_origin_db.sh
+++ b/util/pg_data_types/reset_origin_db.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+docker rm --force --volumes pg_data_types_origin
+
+docker create --name pg_data_types_origin -p 5500:5432 postgres:9.6.3
+
+docker start pg_data_types_origin
+
+sleep 5
+
+createdb -p 5500 -h localhost -U postgres pg_data_types_origin
+
+psql -f util/pg_data_types/1_pre_data.sql -p 5500 -h localhost -U postgres pg_data_types_origin -v ON_ERROR_STOP=1
+psql -f util/pg_data_types/2_data.sql -p 5500 -h localhost -U postgres pg_data_types_origin -v ON_ERROR_STOP=1
+psql -f util/pg_data_types/3_post_data.sql -p 5500 -h localhost -U postgres pg_data_types_origin -v ON_ERROR_STOP=1

--- a/util/pg_data_types/reset_target_db.sh
+++ b/util/pg_data_types/reset_target_db.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+docker rm --force --volumes pg_data_types_target
+
+docker create --name pg_data_types_target -p 5501:5432 postgres:9.6.3
+
+docker start pg_data_types_target
+
+sleep 5
+
+createdb -p 5501 -h localhost -U postgres pg_data_types_target
+
+pg_dump -h localhost -p 5500 -U postgres --section=pre-data pg_data_types_origin | psql -h localhost -p 5501 -U postgres pg_data_types_target -v ON_ERROR_STOP=1

--- a/util/school_db/1_pre_data.sql
+++ b/util/school_db/1_pre_data.sql
@@ -6,10 +6,10 @@ CREATE TABLE districts (
 );
 
 CREATE TABLE schools (
-  id          SERIAL PRIMARY KEY,
   district_id INTEGER   NOT NULL, -- Foreign Key purposely left out (must be specified manually as argument on program startup)
   name        TEXT      NOT NULL,
-  mascot      TEXT      NOT NULL,
+  mascot      TEXT      NULL,
+  id          SERIAL PRIMARY KEY, -- Edge case: PK is not first column in table and appears after a column that is marked as excluded (mascot).
   created_at  TIMESTAMP NOT NULL,
   updated_at  TIMESTAMP NOT NULL
 );

--- a/util/school_db/2_data.sql
+++ b/util/school_db/2_data.sql
@@ -120,7 +120,7 @@ INSERT INTO "Audit".events (id, event_type_key, district_id, school_id, student_
     now()
   FROM school_assignments sa
     INNER JOIN schools sc ON sa.school_id = sc.id
-    CROSS JOIN generate_series(0, 100) AS seq; -- (0, 2000) would generate ~ 200 GB of data once indices are created
+    CROSS JOIN generate_series(0, 10) AS seq; -- (0, 2000) would generate ~ 200 GB of data once indices are created
 
 -- "Polymorphic foreign key" data
 INSERT INTO multiple_choice_assignments (id, assignment_name, created_at) VALUES
@@ -145,23 +145,22 @@ INSERT INTO essay_assignments (id, name, created_at) VALUES
 INSERT INTO homework_grades (student_id, assignment_type, assignment_id, grade, autograded, created_at, updated_at)
   SELECT
     s.student_id,
-    (SELECT sub.*
-     FROM (SELECT unnest(ARRAY ['worksheet', 'essay', 'multiple choice'])) sub
-     ORDER BY random()
-     LIMIT 1),
-    (SELECT sub.*
-     FROM (SELECT unnest(ARRAY [1, 2, 3, 4])) sub
-     ORDER BY random()
-     LIMIT 1),
+    CASE WHEN seq % 3 = 0
+      THEN 'worksheet'
+    WHEN seq % 5 = 0
+      THEN 'essay'
+    ELSE 'multiple choice' END,
+    -- randomly pick an assignment type
+    seq % 4 + 1,
+    -- random number from 1 to 4
     random(),
-    (SELECT sub.*
-     FROM (SELECT unnest(ARRAY [TRUE, FALSE])) sub
-     ORDER BY random()
-     LIMIT 1),
+    CASE WHEN seq % 3 = 0
+      THEN TRUE
+    ELSE FALSE END,
     now(),
     now()
   FROM "Students" s
-    CROSS JOIN generate_series(0, 100) AS seq;
+    CROSS JOIN generate_series(0, 3) AS seq;
 
 -- Isolated table data
 INSERT INTO standalone_table (note, created_on) VALUES

--- a/util/school_db/post_subset_target.sh
+++ b/util/school_db/post_subset_target.sh
@@ -3,3 +3,5 @@
 set -e
 
 pg_dump -h localhost -p 5450 -U postgres --section=post-data db_subsetter_origin | psql -h localhost -p 5451 -U postgres db_subsetter_target -v ON_ERROR_STOP=1
+
+psql -h localhost -p 5451 -U postgres -d db_subsetter_target -c 'alter table schools add foreign key (district_id) references districts ("Id")'


### PR DESCRIPTION
After testing many different postgres data types and seeing that most of them are supported, but a small number are not, I've added the option to exclude certain columns from the subset. The idea would be that columns of custom data types which are not supported out-of-the box by the postgres jdbc driver (or whatever db jdbc driver is in use) would be handled manually by the user outside of the scope of the DBSubsetter project.

We may try to add better support for these data types in the future, but for now, the `--excludeColumns` option seems like the simplest workaround.