### PR TITLE
Remove "where clause" feature from custom foreign key specification

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -9,3 +9,5 @@
 * Consider better support for uncommon data types such as money, enums, arrays of enums, etc
   -- Could the enum case be addressed via type casting in a way that does not cause other bugs or harm performance?
 * Add README.md
+* Test a self-referencing foreign key
+* Add option to support Rails "polymorphic associations" / Hibernate "discriminator column STI"

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,4 +1,3 @@
-* Investigate seemingly broken where-clause foreign key feature in school db
 * Test the akka-streams versions of things against the singleThreadedDebugMode
 * Add some sort of way to shut down or otherwise finish the akka-streams version instead of hanging forever (otherwise how can we do automated tests of it?)
 * Try to support MySQL, SQL Server, and Oracle
@@ -11,3 +10,4 @@
 * Add README.md
 * Test a self-referencing foreign key
 * Add option to support Rails "polymorphic associations" / Hibernate "discriminator column STI"
+* Consider if/how PkStore could use TreeSet instead of HashSet, and if that would be faster in practice

--- a/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
+++ b/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
@@ -17,6 +17,7 @@ object ApplicationSingleThreaded {
     val queue = mutable.Queue.empty[OriginDbRequest]
     baseQueries.foreach(t => queue.enqueue(t))
 
+    val start = System.nanoTime()
     // Run task queue until empty
     while (queue.nonEmpty) {
       val taskOpt: List[OriginDbRequest] = queue.dequeue() match {
@@ -31,5 +32,8 @@ object ApplicationSingleThreaded {
         newTasks.foreach(fkt => queue.enqueue(fkt))
       }
     }
+    val end = System.nanoTime()
+    val tookSeconds = (end - start) / 1000000000
+    println(s"Done! Took $tookSeconds seconds")
   }
 }

--- a/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
+++ b/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
@@ -1,7 +1,7 @@
 package trw.dbsubsetter.config
 
 import scopt.OptionParser
-import trw.dbsubsetter.db.{ColumnName, SchemaName, TableName, WhereClause}
+import trw.dbsubsetter.db.{ColumnName, SchemaName, TableName}
 
 object CommandLineParser {
   val parser: OptionParser[Config] = new OptionParser[Config]("DBSubsetter") {
@@ -47,17 +47,13 @@ object CommandLineParser {
 
     opt[String]("foreignKey")
       .maxOccurs(Int.MaxValue)
-      .valueName("<schema1>.<table1>(<column1>, <column2>, ...) ::: <schema2>.<table2>(<column3>, <column4>, ...) [::: whereClause]")
+      .valueName("<schema1>.<table1>(<column1>, <column2>, ...) ::: <schema2>.<table2>(<column3>, <column4>, ...)")
       .action { case (fk, c) =>
-        val whereClauseFkRegex = """(.+)\.(.+)\((.+)\)\s*:::\s*(.+)\.(.+)\((.+)\)\s*:::\s*(.+)""".r
-        val standardFkRegex = """(.+)\.(.+)\((.+)\)\s*:::\s*(.+)\.(.+)\((.+)\)""".r
+        val regex = """(.+)\.(.+)\((.+)\)\s*:::\s*(.+)\.(.+)\((.+)\)""".r
 
         fk match {
-          case whereClauseFkRegex(fromSch, fromTbl, fromCols, toSch, toTbl, toCols, whereClause) =>
-            val fk = CmdLineForeignKey(fromSch, fromTbl, fromCols.split(",").toList.map(_.trim), toSch, toTbl, toCols.split(",").toList, Some(whereClause))
-            c.copy(cmdLineForeignKeys = fk :: c.cmdLineForeignKeys)
-          case standardFkRegex(fromSch, fromTbl, fromCols, toSch, toTbl, toCols) =>
-            val fk = CmdLineForeignKey(fromSch, fromTbl, fromCols.split(",").toList.map(_.trim), toSch, toTbl, toCols.split(",").toList, None)
+          case regex(fromSch, fromTbl, fromCols, toSch, toTbl, toCols) =>
+            val fk = CmdLineForeignKey(fromSch, fromTbl, fromCols.split(",").toList.map(_.trim), toSch, toTbl, toCols.split(",").toList)
             c.copy(cmdLineForeignKeys = fk :: c.cmdLineForeignKeys)
           case _ => throw new RuntimeException()
         }
@@ -158,8 +154,7 @@ case class CmdLineForeignKey(fromSchema: SchemaName,
                              fromColumns: List[ColumnName],
                              toSchema: SchemaName,
                              toTable: TableName,
-                             toColumns: List[ColumnName],
-                             whereClause: Option[WhereClause])
+                             toColumns: List[ColumnName])
 
 case class CmdLinePrimaryKey(schema: SchemaName,
                              table: TableName,

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -60,8 +60,7 @@ object SchemaInfoRetrieval {
           foreignKeysJdbcResultSet.getString("FKCOLUMN_NAME"),
           foreignKeysJdbcResultSet.getString("PKTABLE_SCHEM"),
           foreignKeysJdbcResultSet.getString("PKTABLE_NAME"),
-          foreignKeysJdbcResultSet.getString("PKCOLUMN_NAME"),
-          None
+          foreignKeysJdbcResultSet.getString("PKCOLUMN_NAME")
         )
       }
     }
@@ -92,7 +91,7 @@ object SchemaInfoRetrieval {
     val foreignKeys: Set[ForeignKey] = {
       val userSuppliedPartialFks: Seq[ForeignKeyQueryRow] = config.cmdLineForeignKeys.flatMap { cfk =>
         cfk.fromColumns.zip(cfk.toColumns).map { case (fromCol, toCol) =>
-          ForeignKeyQueryRow(cfk.fromSchema, cfk.fromTable, fromCol, cfk.toSchema, cfk.toTable, toCol, cfk.whereClause)
+          ForeignKeyQueryRow(cfk.fromSchema, cfk.fromTable, fromCol, cfk.toSchema, cfk.toTable, toCol)
         }
       }
       val allPartialFKs = userSuppliedPartialFks ++ foreignKeysQueryResult
@@ -108,7 +107,7 @@ object SchemaInfoRetrieval {
             pkOpt.fold(false)(pkColOrdinals => pkColOrdinals == toCols.map(_.ordinalPosition))
           }
 
-          ForeignKey(fromCols, toCols, pointsToPk, partialForeignKeys.head.whereClauseOpt)
+          ForeignKey(fromCols, toCols, pointsToPk)
         }.toSet
     }
 
@@ -143,8 +142,7 @@ object SchemaInfoRetrieval {
                                               fromColumn: ColumnName,
                                               toSchema: SchemaName,
                                               toTable: TableName,
-                                              toColumn: ColumnName,
-                                              whereClauseOpt: Option[WhereClause])
+                                              toColumn: ColumnName)
 
 }
 

--- a/src/main/scala/trw/dbsubsetter/db/Sql.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Sql.scala
@@ -9,23 +9,8 @@ object Sql {
 
     allCombos.map { case (fk, table) =>
       val whereClauseCols = if (table == fk.toTable) fk.toCols else fk.fromCols
-      val whereClauseColumnParts = whereClauseCols.map(col => s"${col.fullyQualifiedName} = ?")
-
-      val sqlString = fk match {
-        case ForeignKey(_, _, _, None) =>
-          makeQueryString(table, whereClauseColumnParts.mkString(" and "), sch)
-        case ForeignKey(fromCols, toCols, _, Some(additionalWhereClause)) =>
-          val selectCols = sch.colsByTableOrdered(table).map(_.fullyQualifiedName).mkString(", ")
-          val whereClause = (whereClauseColumnParts :+ additionalWhereClause).mkString(" and ")
-          val otherTable = if (table == fk.toTable) fk.fromTable else fk.toTable
-          val joinClause = fromCols.zip(toCols).map { case (f, t) => s"${f.fullyQualifiedName} = ${t.fullyQualifiedName}" }.mkString(" and ")
-          s"""select $selectCols
-             | from ${table.fullyQualifiedName}
-              | inner join ${otherTable.fullyQualifiedName} on $joinClause
-              | where $whereClause""".stripMargin
-
-      }
-      (fk, table) -> sqlString
+      val whereClause = whereClauseCols.map(col => s"${col.fullyQualifiedName} = ?").mkString(" and ")
+      (fk, table) -> makeQueryString(table, whereClause, sch)
     }.toMap
   }
 

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -30,7 +30,7 @@ package object db {
     val fullyQualifiedName: String = s"""${table.fullyQualifiedName}.$quotedName"""
   }
 
-  case class ForeignKey(fromCols: Vector[Column], toCols: Vector[Column], pointsToPk: Boolean, additionalWhereClauseOpt: Option[WhereClause]) {
+  case class ForeignKey(fromCols: Vector[Column], toCols: Vector[Column], pointsToPk: Boolean) {
     val fromTable: Table = fromCols.head.table
     val toTable: Table = toCols.head.table
 

--- a/src/test/scala/e2e/MissingFkTest.scala
+++ b/src/test/scala/e2e/MissingFkTest.scala
@@ -21,11 +21,7 @@ class MissingFkTest extends FunSuite with BeforeAndAfterAll {
       "--originDbConnStr", "jdbc:postgresql://localhost:5490/missing_fk_origin?user=postgres",
       "--targetDbConnStr", targetConnString,
       "--baseQuery", "public.table_1=id = 2",
-      "--baseQuery", "public.table_a=id in (1, 2, 4, 5)",
       "--foreignKey", "public.table_2(table_1_id) ::: public.table_1(id)",
-      "--foreignKey", "public.table_a(points_to_table_id) ::: public.table_b(id) ::: table_a.points_to_table_name='points_to_table_b'",
-      "--foreignKey", "public.table_a(points_to_table_id) ::: public.table_c(id) ::: table_a.points_to_table_name='points_to_table_c'",
-      "--foreignKey", "public.table_a(points_to_table_id) ::: public.table_d(id) ::: table_a.points_to_table_name='points_to_table_d'",
       "--primaryKey", "public.table_4(table_1_id, table_3_id)",
       "--originDbParallelism", "1",
       "--targetDbParallelism", "1",
@@ -98,6 +94,7 @@ class MissingFkTest extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Correct table_a records were included") {
+    pending
     val resultSet = targetConn.createStatement().executeQuery("select * from table_a order by id asc")
     resultSet.next()
     val id1 = resultSet.getInt("id")
@@ -115,6 +112,7 @@ class MissingFkTest extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Correct table_b records were included") {
+    pending
     val resultSet = targetConn.createStatement().executeQuery("select * from table_b")
     resultSet.next()
     val id1 = resultSet.getInt("id")
@@ -126,6 +124,7 @@ class MissingFkTest extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Correct table_c records were included") {
+    pending
     val resultSet = targetConn.createStatement().executeQuery("select count(*) from table_c")
     resultSet.next()
     val count = resultSet.getInt(1)
@@ -133,7 +132,8 @@ class MissingFkTest extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Correct table_d records were included") {
-    val resultSet = targetConn.createStatement().executeQuery("select * from table_d")
+    pending
+    val resultSet = targetConn.createStatement().executeQuery("select * from table_d order by id asc")
     resultSet.next()
     val id1 = resultSet.getInt("id")
     assert(id1 === 2)

--- a/util/missing_fk/2_data.sql
+++ b/util/missing_fk/2_data.sql
@@ -9,7 +9,13 @@ INSERT INTO table_a (id, points_to_table_name, points_to_table_id) VALUES
   (2, 'points_to_table_b', 1),
   (3, 'points_to_table_b', 2),
   (4, 'points_to_table_d', 2),
-  (5, 'points_to_table_d', 30); -- edge case -- id does not exist in target table
+  -- edge case -- id does not exist in target table
+  (5, 'points_to_table_d', 30),
+  -- edge case -- Row 6 is NOT part of the subset, so row 1 of table_d should NOT be included
+  -- however, row #1 of table_b SHOULD be included.
+  -- This helps to test that table_b subsetting is not accidentally leaking over into table_d
+  -- This is based on a real bug that used to exist in our code
+  (6, 'points_to_table_d', 1);
 
 INSERT INTO table_b (id) VALUES (1), (2), (3);
 INSERT INTO table_c (id) VALUES (1), (2), (3);


### PR DESCRIPTION
Unfortunately the original implementation of the "where clause in custom FK" feature was not very performant and it also contained a bug mentioned in this new comment in the test suite:

```
-- edge case -- Row 6 is NOT part of the subset, so row 1 of table_d should NOT be included
-- however, row #1 of table_b SHOULD be included.
-- This helps to test that table_b subsetting is not accidentally leaking over into table_d
-- This is based on a real bug that used to exist in our code
```

Hopefully we can reinstate this feature in the future, but it might take a different form, such as explicitly being modeled after Rails "polymorphic associations" / Hibernate "discrimitator columns", i.e. not allowing free-form where clauses.

Currently, this branch is the most likely to contain a corrected version of this feature, although it is not clear if or when this will happen. https://github.com/bluerogue251/DBSubsetter/tree/fix_bug_with_custom_fk_where_clause

These are the types of slow/buggy queries that were being used:

```sql
select "public"."worksheet_assignments"."id", "public"."worksheet_assignments"."worksheet_assignment_name"
from "public"."worksheet_assignments"
  inner join "public"."homework_grades" on "public"."homework_grades"."assignment_id" = "public"."worksheet_assignments"."id"
where "public"."worksheet_assignments"."id" = $1 and homework_grades.assignment_type='worksheet';
```

notice how in this query a huge result set is returned, even though we only really want 1 row due to the inner join. Also calling `limit 1` did not seem to substantially help things, and in any case the above mentioned bug still existed even with `limit 1`.