### PR TITLE
Skip making new tasks to fetch parents that have already been fetched

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Memory usage will be proportional to the size of all the primary keys in the tar
 
 ## Contributing
 
-Contributions of all kinds are welcome and appreciated here! Whether it is to fix a typo, improve the documentation, add more tests, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on GitHub.
+Contributions of all kinds are welcome and appreciated here! Whether it is to fix a typo, improve the documentation, add more tests, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on the project [GitHub page](https://github.com/bluerogue251/DBSubsetter).
 
 The only condition for contributing to this project is to follow our [code of conduct](CODE_OF_CONDUCT.md) so that everyone is treated with respect.
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Memory usage will be proportional to the size of all the primary keys in the tar
 
 ## Contributing
 
-Contributions of all kinds are welcome and appreciated here! Whether it is to fix a typo, improve the documentation, add more tests, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on the project [GitHub page](https://github.com/bluerogue251/DBSubsetter).
+Contributions of all kinds are welcome here!
+
+Whether it is to fix a typo, improve the documentation, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on the project [GitHub page](https://github.com/bluerogue251/DBSubsetter).
 
 The only condition for contributing to this project is to follow our [code of conduct](CODE_OF_CONDUCT.md) so that everyone is treated with respect.
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,7 @@ Memory usage will be proportional to the size of all the primary keys in the tar
 
 ## Contributing
 
-Contributions of all kinds are welcome and appreciated here!
-
-Whether it is to fix a typo, improve the documentation, add more tests, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on GitHub.
+Contributions of all kinds are welcome and appreciated here! Whether it is to fix a typo, improve the documentation, add more tests, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on GitHub.
 
 The only condition for contributing to this project is to follow our [code of conduct](CODE_OF_CONDUCT.md) so that everyone is treated with respect.
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,6 +1,5 @@
-* Improve and test command line parsing with better error messages
-* Add retry logic to DB Queries in case of failure, e.g. due to temporary network problem
-* Search for memory/performance bottlenecks by profiling against a huge database
 * Consider if for certain schemas we can skip storing certain tables' PKs because we know we will only ever see a row once?
+* Search for memory/performance bottlenecks by profiling against a huge database
 * Investigate whether optimization is possible via changing AnyRef to Any and then using primitive Ints instead of Integer for PK storage, etc.
 * Investigate whether optimization is possible via using a TreeSet instead of a HashSet for PK Storage
+* Add retry logic to DB Queries in case of failure, e.g. due to temporary network problem

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,3 +1,4 @@
+* Improve and test command line parsing with better error messages
 * Consider if for certain schemas we can skip storing certain tables' PKs because we know we will only ever see a row once?
 * Search for memory/performance bottlenecks by profiling against a huge database
 * Investigate whether optimization is possible via changing AnyRef to Any and then using primitive Ints instead of Integer for PK storage, etc.

--- a/src/main/scala/trw/dbsubsetter/workflow/NewFkTaskWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/NewFkTaskWorkflow.scala
@@ -4,16 +4,23 @@ import trw.dbsubsetter.db._
 
 object NewFkTaskWorkflow {
   def process(pksAdded: PksAdded, sch: SchemaInfo): Vector[FkTask] = {
-    val PksAdded(table, rowsNeedingParentTasks, rowsNeedingChildTasks) = pksAdded
-    val parentTasks = calcParentTasks(sch, table, rowsNeedingParentTasks)
+    val PksAdded(table, rowsNeedingParentTasks, rowsNeedingChildTasks, viaTableOpt) = pksAdded
+    val parentTasks = calcParentTasks(sch, table, rowsNeedingParentTasks, viaTableOpt)
     val childTasks = calcChildTasks(sch, table, rowsNeedingChildTasks)
     parentTasks ++ childTasks
   }
 
-  private def calcParentTasks(sch: SchemaInfo, table: Table, rows: Vector[Row]): Vector[FkTask] = {
-    // `distinct` is (hopefully) a performance improvement which prevents duplicate tasks from being created
-    // As far as I can tell, it is only necessary for parent tasks
-    sch.fksFromTable(table).toVector.flatMap { fk =>
+  private def calcParentTasks(sch: SchemaInfo, table: Table, rows: Vector[Row], viaTableOpt: Option[Table]): Vector[FkTask] = {
+    // Re: `distinct`
+    // It is (hopefully) a performance improvement which prevents duplicate tasks from being created
+    //
+    // Re: `viaTableOpt`
+    // If we know that the reason we fetched a row to begin with is that it is the child of some row we've
+    // already fetched, then we know that we don't need to go fetch that particular parent row again
+    //
+    // `distinct` and `viaTableOpt` only apply for calculating parent tasks, not child tasks.
+    // Both of these seem necessary for avoiding always needing to store PKs for all parents of base queries
+    sch.fksFromTable(table).filterNot(fk => viaTableOpt.contains(fk.toTable)).toVector.flatMap { fk =>
       val distinctFkValues = getForeignKeyValues(fk, fk.fromCols, rows).distinct
       distinctFkValues.map(fkValue => FkTask(fk.toTable, fk, fkValue, fetchChildren = false))
     }

--- a/src/main/scala/trw/dbsubsetter/workflow/NewFkTaskWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/NewFkTaskWorkflow.scala
@@ -19,8 +19,10 @@ object NewFkTaskWorkflow {
     // already fetched, then we know that we don't need to go fetch that particular parent row again
     //
     // `distinct` and `viaTableOpt` only apply for calculating parent tasks, not child tasks.
-    // Both of these seem necessary for avoiding always needing to store PKs for all parents of base queries
-    sch.fksFromTable(table).filterNot(fk => viaTableOpt.contains(fk.toTable)).toVector.flatMap { fk =>
+    // Both of these seem necessary for avoiding always needing to store PKs for all parents
+    val allFks = sch.fksFromTable(table)
+    val useFks = viaTableOpt.fold(allFks)(viaTable => allFks.filterNot(fk => fk.toTable == viaTable))
+    useFks.toVector.flatMap { fk =>
       val distinctFkValues = getForeignKeyValues(fk, fk.fromCols, rows).distinct
       distinctFkValues.map(fkValue => FkTask(fk.toTable, fk, fkValue, fetchChildren = false))
     }

--- a/src/main/scala/trw/dbsubsetter/workflow/OriginDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/OriginDbWorkflow.scala
@@ -11,10 +11,11 @@ class OriginDbWorkflow(config: Config, schemaInfo: SchemaInfo) {
     request match {
       case FkTask(table, foreignKey, fkValue, fetchChildren) =>
         val rows = db.getRowsFromTemplate(foreignKey, table, fkValue)
-        OriginDbResult(table, rows, fetchChildren)
+        val viaTableOpt = if (fetchChildren) Some(foreignKey.toTable) else None
+        OriginDbResult(table, rows, viaTableOpt, fetchChildren)
       case SqlStrQuery(table, sql, fetchChildren) =>
         val rows = db.getRows(sql, table)
-        OriginDbResult(table, rows, fetchChildren)
+        OriginDbResult(table, rows, None, fetchChildren)
     }
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/PkStoreWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/PkStoreWorkflow.scala
@@ -28,7 +28,7 @@ class PkStoreWorkflow(pkOrdinalsByTable: Map[Table, Seq[Int]]) {
   }
 
   def add(req: OriginDbResult): PksAdded = {
-    val OriginDbResult(table, rows, fetchChildren) = req
+    val OriginDbResult(table, rows, viaTableOpt, fetchChildren) = req
     val (parentStore, childStore) = getStorage(table)
 
     val pkOrdinals = pkOrdinalsByTable(table)
@@ -39,13 +39,13 @@ class PkStoreWorkflow(pkOrdinalsByTable: Map[Table, Seq[Int]]) {
     if (fetchChildren) {
       val childrenNotYetFetched = rows.filter(row => childStore.add(getPkValue(row)))
       val parentsNotYetFetched = childrenNotYetFetched.filterNot(row => parentStore.remove(getPkValue(row)))
-      PksAdded(table, parentsNotYetFetched, childrenNotYetFetched)
+      PksAdded(table, parentsNotYetFetched, childrenNotYetFetched, viaTableOpt)
     } else {
       val newRows = rows.filter { row =>
         val pkValue = getPkValue(row)
         !childStore.contains(pkValue) && parentStore.add(pkValue)
       }
-      PksAdded(table, newRows, Vector.empty)
+      PksAdded(table, newRows, Vector.empty, viaTableOpt)
     }
   }
 

--- a/src/main/scala/trw/dbsubsetter/workflow/package.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/package.scala
@@ -10,13 +10,13 @@ package object workflow {
 
   case class SqlStrQuery(table: Table, sql: SqlQuery, fetchChildren: Boolean) extends OriginDbRequest
 
-  case class OriginDbResult(table: Table, rows: Vector[Row], fetchChildren: Boolean)
+  case class OriginDbResult(table: Table, rows: Vector[Row], viaTableOpt: Option[Table], fetchChildren: Boolean)
 
   case class TargetDbInsertResult(table: Table, numRowsInserted: Long)
 
   sealed trait PkResult
 
-  case class PksAdded(table: Table, rowsNeedingParentTasks: Vector[Row], rowsNeedingChildTasks: Vector[Row]) extends PkResult
+  case class PksAdded(table: Table, rowsNeedingParentTasks: Vector[Row], rowsNeedingChildTasks: Vector[Row], viaTableOpt: Option[Table]) extends PkResult
 
   case object DuplicateTask extends PkResult
 }

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -74,9 +74,18 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
     val schemaInfo = SchemaInfoRetrieval.getSchemaInfo(singleThreadedConfig)
     val baseQueries = BaseQueries.get(singleThreadedConfig, schemaInfo)
 
+    val startSt = System.nanoTime()
     ApplicationSingleThreaded.run(singleThreadedConfig, schemaInfo, baseQueries)
+    val endSt = System.nanoTime()
+    val tookMillis = (endSt - startSt) / 1000000
+    println(s"Single Threaded Took $tookMillis milliseconds")
+
+    val startAs = System.nanoTime()
     val futureResult = ApplicationAkkaStreams.run(akkaStreamsConfig, schemaInfo, baseQueries)
     Await.result(futureResult, Duration.Inf)
+    val endAs = System.nanoTime()
+    val tookMillisAs = (endAs - startAs) / 1000000
+    println(s"Akka Streams Took $tookMillisAs milliseconds")
 
     postSubset()
   }

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -14,9 +14,9 @@ class PkStoreWorkflowTest extends FunSuite {
     val rows = Vector(row)
 
     // Add the PK to the pkStore, noting that we have NOT yet fetched children
-    val pkAddRequest1 = OriginDbResult(table, rows, fetchChildren = false)
+    val pkAddRequest1 = OriginDbResult(table, rows, None, fetchChildren = false)
     val pkAddResult1 = pkStore.add(pkAddRequest1)
-    assert(pkAddResult1 === PksAdded(table, rows, Vector.empty))
+    assert(pkAddResult1 === PksAdded(table, rows, Vector.empty, None))
 
     // Query whether the PK is in the pkStore given that we are only interested in parent records
     // The empty list result tells us that the PK exists already
@@ -35,9 +35,9 @@ class PkStoreWorkflowTest extends FunSuite {
     // The fact that it was already in the PK store for having its parents fetched means that
     // It will only appear in the collection of rows still needing children processing
     // It will not appear in the collection of rows needing parents (and therefore will not be added duplicate to the target db either)
-    val pkAddRequest2 = OriginDbResult(table, rows, fetchChildren = true)
+    val pkAddRequest2 = OriginDbResult(table, rows, None, fetchChildren = true)
     val pkAddResult2 = pkStore.add(pkAddRequest2)
-    assert(pkAddResult2 === PksAdded(table, Vector.empty, rows))
+    assert(pkAddResult2 === PksAdded(table, Vector.empty, rows, None))
 
     // Now we query again and since we've already fetched children, we should never get anything back from the queries
     val pkQueryResult3 = pkStore.exists(pkQueryRequest1)


### PR DESCRIPTION
Right now this has unfortunately yielded much less of a performance gain than I expected. Single threaded performance appears to improve only by 3 or 4%, and akka streams performance appears either unaffected or to perhaps even worsen by 1% or so. (Tested against the schooldb postgres test).

Nonetheless, I think this is still a step forward for our algorithm when the long term goals are considered, because we eventually want to stop storing all primary key values. Avoid needlessly fetching parent rows that we've already fetched should help us avoid needlessly storing those parent rows' primary key values in the future.