### PR TITLE
Remove e2e test suite dependencies on pre-installed psql, pg_dump, mysql, etc. utilites

### DIFF
--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -37,7 +37,6 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
 
   protected def dataSetName: String
 
-
   //
   // The following is generic enough that it usually does not need to be overridden
   //
@@ -55,11 +54,6 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
   var akkStreamsRuntimeMillis: Long = 0
   var schemaInfo: SchemaInfo = _
 
-  //
-  // Set this to true the first time you run tests, for initial setup
-  //
-  protected val recreateOriginDB: Boolean = false
-
   override protected def beforeAll(): Unit = {
     super.beforeAll()
 
@@ -74,8 +68,8 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
     val akkaStreamsConfig = CommandLineParser.parser.parse(asArgs, Config()).get
 
     originDb = profile.backend.Database.forURL(singleThreadedConfig.originDbConnectionString)
-    if (recreateOriginDB) setupOriginDDL()
-    if (recreateOriginDB) setupOriginDML()
+    setupOriginDDL()
+    setupOriginDML()
     setupTargetDbs()
     targetDbSt = profile.backend.Database.forURL(singleThreadedConfig.targetDbConnectionString)
     targetDbAs = profile.backend.Database.forURL(akkaStreamsConfig.targetDbConnectionString)

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -5,9 +5,6 @@ import scala.sys.process._
 abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
   override val profile = slick.jdbc.MySQLProfile
 
-  // Unfortunately a bug in MySQL does not allow us to keep around too many containers
-  override protected val recreateOriginDB: Boolean = true
-
   def dataSetName: String
 
   def originContainerName = s"${dataSetName}_origin_mysql"
@@ -18,13 +15,13 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
 
   override def makeConnStr(port: Int, dbName: String): String = s"jdbc:mysql://localhost:$port/$dataSetName?user=root&useSSL=false&rewriteBatchedStatements=true"
 
-  override def setupOriginDb(): Unit = if (recreateOriginDB) createMySqlDatabase(originPort)
+  override def setupOriginDb(): Unit = createMySqlDatabase(originContainerName)
 
   override def setupTargetDbs(): Unit = {
-    createMySqlDatabase(targetSingleThreadedPort)
-    createMySqlDatabase(targetAkkaStreamsPort)
-    s"./src/test/util/sync_mysql_origin_to_target.sh $dataSetName $originPort $targetSingleThreadedPort".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh $dataSetName $originPort $targetAkkaStreamsPort".!!
+    createMySqlDatabase(targetSithContainerName)
+    createMySqlDatabase(targetAkstContainerName)
+    s"./src/test/util/sync_mysql_origin_to_target.sh $dataSetName $originContainerName $targetSithContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh $dataSetName $originContainerName $targetAkstContainerName".!!
   }
 
   override def postSubset(): Unit = {} // No-op
@@ -32,21 +29,21 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
   override protected def createDockerContainers(): Unit = {
     def createAndStart(name: String, port: Int): Unit = {
       dockerRm(name)
-      s"docker create --name $name -p $port:3306 --env MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.0".!!
+      s"docker create --name $name -p $port:3306 --env MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.0.3".!!
       dockerStart(name)
     }
 
-    if (recreateOriginDB) createAndStart(originContainerName, originPort) else dockerStart(originContainerName)
+    createAndStart(originContainerName, originPort)
     createAndStart(targetSithContainerName, targetSingleThreadedPort)
     createAndStart(targetAkstContainerName, targetAkkaStreamsPort)
     Thread.sleep(13000)
   }
 
-  private def createMySqlDatabase(port: Int): Unit = s"./src/test/util/create_mysql_db.sh $dataSetName $port".!!
+  private def createMySqlDatabase(container: String): Unit = s"./src/test/util/create_mysql_db.sh $dataSetName $container".!!
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    if (recreateOriginDB) dockerRm(originContainerName)
+    dockerRm(originContainerName)
     dockerRm(targetSithContainerName)
     dockerRm(targetAkstContainerName)
   }

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -7,7 +7,7 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
 
   def dataSetName: String
 
-  private def originContainerName = s"${dataSetName}_origin_postgres"
+  protected def originContainerName = s"${dataSetName}_origin_postgres"
 
   private def targetSingleThreadedContainerName = s"${dataSetName}_target_sith_postgres"
 

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -48,6 +48,7 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
 
   override protected def afterAll(): Unit = {
     super.afterAll()
+    dockerRm(originContainerName)
     dockerRm(targetSingleThreadedContainerName)
     dockerRm(targetAkkaStreamsContainerName)
   }

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -15,18 +15,18 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
 
   override def makeConnStr(p: Int, dbName: String): String = s"jdbc:postgresql://0.0.0.0:$p/$dataSetName?user=postgres"
 
-  override def setupOriginDb(): Unit = if (recreateOriginDB) createDb(originPort)
+  override def setupOriginDb(): Unit = createDb(originContainerName)
 
   override def setupTargetDbs(): Unit = {
-    createDb(targetSingleThreadedPort)
-    createDb(targetAkkaStreamsPort)
-    s"./src/test/util/sync_postgres_origin_to_target.sh $dataSetName $originPort $targetSingleThreadedPort".!!
-    s"./src/test/util/sync_postgres_origin_to_target.sh $dataSetName $originPort $targetAkkaStreamsPort".!!
+    createDb(targetSingleThreadedContainerName)
+    createDb(targetAkkaStreamsContainerName)
+    s"./src/test/util/sync_postgres_origin_to_target.sh $dataSetName $originContainerName $targetSingleThreadedContainerName".!!
+    s"./src/test/util/sync_postgres_origin_to_target.sh $dataSetName $originContainerName $targetAkkaStreamsContainerName".!!
   }
 
   override def postSubset(): Unit = {
-    s"./src/test/util/postgres_post_subset.sh $dataSetName $originPort $targetSingleThreadedPort".!!
-    s"./src/test/util/postgres_post_subset.sh $dataSetName $originPort $targetAkkaStreamsPort".!!
+    s"./src/test/util/postgres_post_subset.sh $dataSetName $originContainerName $targetSingleThreadedContainerName".!!
+    s"./src/test/util/postgres_post_subset.sh $dataSetName $originContainerName $targetAkkaStreamsContainerName".!!
   }
 
   override protected def createDockerContainers(): Unit = {
@@ -36,14 +36,14 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
       dockerStart(name)
     }
 
-    if (recreateOriginDB) createAndStart(originContainerName, originPort) else dockerStart(originContainerName)
+    createAndStart(originContainerName, originPort)
     createAndStart(targetSingleThreadedContainerName, targetSingleThreadedPort)
     createAndStart(targetAkkaStreamsContainerName, targetAkkaStreamsPort)
     Thread.sleep(5000)
   }
 
-  private def createDb(port: Int): Unit = {
-    s"createdb --port $port --host 0.0.0.0 --user postgres $dataSetName".!!
+  private def createDb(dockerContainer: String): Unit = {
+    s"docker exec $dockerContainer createdb --user postgres $dataSetName".!!
   }
 
   override protected def afterAll(): Unit = {

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -5,8 +5,6 @@ import scala.sys.process._
 abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
   override val profile = slick.jdbc.SQLServerProfile
 
-  override protected val recreateOriginDB: Boolean = true
-
   override lazy val targetSingleThreadedPort: Int = originPort
   override lazy val targetAkkaStreamsPort: Int = originPort
   override lazy val targetSingleThreadedDbName = s"${dataSetName}_sith"
@@ -16,7 +14,7 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
   override def makeConnStr(port: Int, dbName: String): String = s"jdbc:sqlserver://localhost:$port;databaseName=$dbName;user=sa;password=MsSqlServerLocal1"
 
   override def setupOriginDb(): Unit = {
-    if (recreateOriginDB) s"./src/test/util/create_sqlserver_db.sh $containerName $dataSetName".!!
+    s"./src/test/util/create_sqlserver_db.sh $containerName $dataSetName".!!
   }
 
   override def setupTargetDbs(): Unit = {
@@ -30,20 +28,18 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
   }
 
   override protected def createDockerContainers(): Unit = {
-    if (recreateOriginDB) {
-      dockerRm(containerName)
-      // Still having trouble with
-      // https://github.com/Microsoft/mssql-docker/issues/181
-      // https://github.com/Microsoft/mssql-docker/issues/171
-      // even when we explicitly specify command `/opt/mssql/bin/sqlservr`
-      s"docker create --name $containerName -p $originPort:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU2 /opt/mssql/bin/sqlservr".!!
-    }
+    dockerRm(containerName)
+    // Still having trouble with
+    // https://github.com/Microsoft/mssql-docker/issues/181
+    // https://github.com/Microsoft/mssql-docker/issues/171
+    // even when we explicitly specify command `/opt/mssql/bin/sqlservr`
+    s"docker create --name $containerName -p $originPort:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU2 /opt/mssql/bin/sqlservr".!!
     dockerStart(containerName)
     Thread.sleep(6000)
   }
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    if (recreateOriginDB) dockerRm(containerName)
+    dockerRm(containerName)
   }
 }

--- a/src/test/scala/e2e/circulardep/CircularDepMysqlTest.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepMysqlTest.scala
@@ -3,8 +3,6 @@ package e2e.circulardep
 import e2e.AbstractMysqlEndToEndTest
 
 class CircularDepMysqlTest extends AbstractMysqlEndToEndTest with CircularDepTestCases {
-  override protected val recreateOriginDB: Boolean = false
-
   override val originPort = 5480
   override val programArgs = Array(
     "--schemas", "circular_dep",

--- a/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
@@ -12,27 +12,27 @@ class CrossSchemaMysqlTest extends AbstractMysqlEndToEndTest with CrossSchemaTes
   )
 
   override def setupOriginDDL(): Unit = {
-    s"./src/test/util/create_mysql_db.sh schema_1 $originPort".!!
-    s"./src/test/util/create_mysql_db.sh schema_2 $originPort".!!
-    s"./src/test/util/create_mysql_db.sh schema_3 $originPort".!!
+    s"./src/test/util/create_mysql_db.sh schema_1 $originContainerName".!!
+    s"./src/test/util/create_mysql_db.sh schema_2 $originContainerName".!!
+    s"./src/test/util/create_mysql_db.sh schema_3 $originContainerName".!!
     super.setupOriginDDL()
   }
 
   override def setupTargetDbs(): Unit = {
     super.setupTargetDbs()
 
-    s"./src/test/util/create_mysql_db.sh schema_1 $targetSingleThreadedPort".!!
-    s"./src/test/util/create_mysql_db.sh schema_2 $targetSingleThreadedPort".!!
-    s"./src/test/util/create_mysql_db.sh schema_3 $targetSingleThreadedPort".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 $originPort $targetSingleThreadedPort".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 $originPort $targetSingleThreadedPort".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 $originPort $targetSingleThreadedPort".!!
+    s"./src/test/util/create_mysql_db.sh schema_1 $targetSithContainerName".!!
+    s"./src/test/util/create_mysql_db.sh schema_2 $targetSithContainerName".!!
+    s"./src/test/util/create_mysql_db.sh schema_3 $targetSithContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 $originContainerName $targetSithContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 $originContainerName $targetSithContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 $originContainerName $targetSithContainerName".!!
 
-    s"./src/test/util/create_mysql_db.sh schema_1 $targetAkkaStreamsPort".!!
-    s"./src/test/util/create_mysql_db.sh schema_2 $targetAkkaStreamsPort".!!
-    s"./src/test/util/create_mysql_db.sh schema_3 $targetAkkaStreamsPort".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 $originPort $targetAkkaStreamsPort".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 $originPort $targetAkkaStreamsPort".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 $originPort $targetAkkaStreamsPort".!!
+    s"./src/test/util/create_mysql_db.sh schema_1 $targetAkstContainerName".!!
+    s"./src/test/util/create_mysql_db.sh schema_2 $targetAkstContainerName".!!
+    s"./src/test/util/create_mysql_db.sh schema_3 $targetAkstContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 $originContainerName $targetAkstContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 $originContainerName $targetAkstContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 $originContainerName $targetAkstContainerName".!!
   }
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaPostgresqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaPostgresqlTest.scala
@@ -1,8 +1,11 @@
 package e2e.crossschema
 
 import e2e.AbstractPostgresqlEndToEndTest
+import slick.dbio.DBIO
+import slick.jdbc.PostgresProfile.api._
 
-import scala.sys.process._
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 class CrossSchemaPostgresqlTest extends AbstractPostgresqlEndToEndTest with CrossSchemaTestCases {
   override val originPort = 5543
@@ -12,7 +15,12 @@ class CrossSchemaPostgresqlTest extends AbstractPostgresqlEndToEndTest with Cros
   )
 
   override def setupOriginDDL(): Unit = {
-    s"psql --host 0.0.0.0 --port $originPort --user postgres $dataSetName --file ./src/test/scala/e2e/crossschema/create_schemas_postgresql.sql".!!
+    val createSchemaStatements: DBIO[Unit] = DBIO.seq(
+      sqlu"create schema schema_1",
+      sqlu"create schema schema_2",
+      sqlu"create schema schema_3"
+    )
+    Await.ready(originDb.run(createSchemaStatements), Duration.Inf)
     super.setupOriginDDL()
   }
 }

--- a/src/test/scala/e2e/crossschema/create_schemas_postgresql.sql
+++ b/src/test/scala/e2e/crossschema/create_schemas_postgresql.sql
@@ -1,3 +1,0 @@
-CREATE SCHEMA schema_1;
-CREATE SCHEMA schema_2;
-CREATE SCHEMA schema_3;

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
@@ -1,5 +1,7 @@
 package e2e.mysqldatatypes
 
+import java.io.File
+
 import e2e.AbstractMysqlEndToEndTest
 
 import scala.sys.process._
@@ -23,7 +25,7 @@ class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest {
     "--baseQuery", "mysql_data_types.referencing_table ::: id in (1, 2, 6, 8, 12, 14, 18, 20, 24, 26, 30) ::: includeChildren"
   )
 
-  test("No error was thrown during subsetting -- TODO write some real tests here") {
+  test("No error was thrown during subsetting -- TODO add more detailed assertions") {
     pending
   }
 
@@ -34,11 +36,15 @@ class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest {
     assertResult(sql, Seq(("mysql_data_types.referencing_table", "1211714113")))
   }
 
+  private val originMySqlCommand = s"docker exec -i $originContainerName mysql --user root $originDbName"
+
   override protected def setupOriginDDL(): Unit = {
-    s"./src/test/scala/e2e/mysqldatatypes/load_ddl.sh $originPort $dataSetName".!!
+    val ddlFile = new File("./src/test/scala/e2e/mysqldatatypes/ddl.sql")
+    (ddlFile #> originMySqlCommand).!!
   }
 
   override protected def setupOriginDML(): Unit = {
-    s"./src/test/scala/e2e/mysqldatatypes/load_dml.sh $originPort $dataSetName".!!
+    val dmlFile = new File("./src/test/scala/e2e/mysqldatatypes/dml.sql")
+    (dmlFile #> originMySqlCommand).!!
   }
 }

--- a/src/test/scala/e2e/mysqldatatypes/load_ddl.sh
+++ b/src/test/scala/e2e/mysqldatatypes/load_ddl.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -eou pipefail
-
-
-port=$1
-data_set_name=$2
-
-mysql --host 0.0.0.0 --port ${port} --user root ${data_set_name} < ./src/test/scala/e2e/mysqldatatypes/ddl.sql

--- a/src/test/scala/e2e/mysqldatatypes/load_dml.sh
+++ b/src/test/scala/e2e/mysqldatatypes/load_dml.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -eou pipefail
-
-
-port=$1
-data_set_name=$2
-
-mysql --host 0.0.0.0 --port ${port} --user root ${data_set_name} < ./src/test/scala/e2e/mysqldatatypes/dml.sql

--- a/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
@@ -1,5 +1,7 @@
 package e2e.pgdatatypes
 
+import java.io.File
+
 import e2e.AbstractPostgresqlEndToEndTest
 
 import scala.sys.process._
@@ -31,15 +33,19 @@ class PgDataTypesPostgresqlTest extends AbstractPostgresqlEndToEndTest {
     "--excludeColumns", "public.bit_string_table(bit_1, bit_5)"
   )
 
-  test("No error was thrown during subsetting -- TODO write some real tests") {
+  test("No error was thrown during subsetting -- TODO write some more assertions") {
     pending
   }
 
+  private val originPsqlCommand = s"docker exec -i $originContainerName psql --user postgres $dataSetName"
+
   override protected def setupOriginDDL(): Unit = {
-    s"psql --host 0.0.0.0 --port $originPort --user postgres $dataSetName --file ./src/test/scala/e2e/pgdatatypes/ddl.sql".!!
+    val ddlFile = new File("./src/test/scala/e2e/pgdatatypes/ddl.sql")
+    (ddlFile #> originPsqlCommand).!!
   }
 
   override protected def setupOriginDML(): Unit = {
-    s"psql --host 0.0.0.0 --port $originPort --user postgres $dataSetName --file ./src/test/scala/e2e/pgdatatypes/dml.sql".!!
+    val dmlFile = new File("./src/test/scala/e2e/pgdatatypes/dml.sql")
+    (dmlFile #> originPsqlCommand).!!
   }
 }

--- a/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
@@ -33,7 +33,7 @@ class PgDataTypesPostgresqlTest extends AbstractPostgresqlEndToEndTest {
     "--excludeColumns", "public.bit_string_table(bit_1, bit_5)"
   )
 
-  test("No error was thrown during subsetting -- TODO write some more assertions") {
+  test("No error was thrown during subsetting -- TODO add more detailed assertions") {
     pending
   }
 

--- a/src/test/scala/load/schooldb/SchoolDbPostgresqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbPostgresqlTest.scala
@@ -16,6 +16,7 @@ class SchoolDbPostgresqlTest extends AbstractPostgresqlEndToEndTest with SchoolD
     "--preTargetBufferSize", "10000"
   )
 
+  // Currently broken: must update to match CrossSchemaPostgresqlTest
   override def setupOriginDDL(): Unit = {
     s"psql --host 0.0.0.0 --port $originPort --user postgres $dataSetName --file ./src/test/scala/load/schooldb/create_schemas_postgresql.sql".!!
     super.setupOriginDDL()

--- a/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
@@ -6,7 +6,6 @@ import load.LoadTest
 import scala.sys.process._
 
 class SchoolDbSqlServerTest extends AbstractSqlServerEndToEndTest with SchoolDbTestCases with LoadTest {
-  override protected val recreateOriginDB: Boolean = false
   override val originPort = 5456
   override val programArgs = Array(
     "--schemas", "school_db,Audit",

--- a/src/test/util/create_mysql_db.sh
+++ b/src/test/util/create_mysql_db.sh
@@ -3,6 +3,6 @@
 set -eou pipefail
 
 data_set_name=$1
-port=$2
+container=$2
 
-mysql --port ${port} --host 0.0.0.0 --user root -e "create database $data_set_name"
+docker exec ${container} mysql --user root -e "create database $data_set_name"

--- a/src/test/util/postgres_post_subset.sh
+++ b/src/test/util/postgres_post_subset.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 data_set_name=$1
-origin_port=$2
-target_port=$3
+origin_container=$2
+target_container=$3
 
-pg_dump -h localhost -p ${origin_port} -U postgres --section=post-data ${data_set_name} | psql -h localhost -p ${target_port} -U postgres ${data_set_name} -v ON_ERROR_STOP=1
+docker exec ${origin_container} pg_dump -U postgres --section=post-data ${data_set_name} | docker exec -i ${target_container} psql -U postgres ${data_set_name} -v ON_ERROR_STOP=1

--- a/src/test/util/sync_mysql_origin_to_target.sh
+++ b/src/test/util/sync_mysql_origin_to_target.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 data_set_name=$1
-origin_port=$2
-target_port=$3
+origin_container=$2
+target_container=$3
 
-mysqldump --host 0.0.0.0 --port ${origin_port} --user root --no-data ${data_set_name} | mysql --host 0.0.0.0 --port ${target_port} --user root ${data_set_name}
+docker exec ${origin_container} mysqldump --user root --no-data ${data_set_name} | docker exec -i ${target_container} mysql --user root ${data_set_name}

--- a/src/test/util/sync_postgres_origin_to_target.sh
+++ b/src/test/util/sync_postgres_origin_to_target.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 data_set_name=$1
-origin_port=$2
-target_port=$3
+origin_container=$2
+target_container=$3
 
-pg_dump --host 0.0.0.0 --port ${origin_port} --user postgres --section=pre-data ${data_set_name} | psql --host 0.0.0.0 --port ${target_port} --user postgres ${data_set_name}
+docker exec ${origin_container} pg_dump --user postgres --section=pre-data ${data_set_name} | docker exec -i ${target_container} psql --user postgres ${data_set_name}


### PR DESCRIPTION
* Starts work on https://github.com/bluerogue251/DBSubsetter/issues/38
* Refactors e2e tests so that only `docker` is necessary as a system dependency for running them
* Load tests have NOT been included in this refactor, so external dependencies are likely still needed to run them.
* Related to https://github.com/bluerogue251/DBSubsetter/issues/39 in that this PR removes the `recreateOriginDB` flag for now, since it made it harder to successfully run the local test suites. (The point of this PR is to make it easier to get up and running with the test suite, whereas the `recreateOriginDB` flag defaulting to `false` made it much harder). We may re-add this flag in some other form when we address https://github.com/bluerogue251/DBSubsetter/issues/39.