### PR TITLE
Re-enable SQLServer Tests now that docker container stability issues have been resolved

### DIFF
--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -29,11 +29,7 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
 
   override protected def createDockerContainers(): Unit = {
     dockerRm(containerName)
-    // Still having trouble with
-    // https://github.com/Microsoft/mssql-docker/issues/181
-    // https://github.com/Microsoft/mssql-docker/issues/171
-    // even when we explicitly specify command `/opt/mssql/bin/sqlservr`
-    s"docker create --name $containerName -p $originPort:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU2 /opt/mssql/bin/sqlservr".!!
+    s"docker create --name $containerName -p $originPort:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU12 /opt/mssql/bin/sqlservr".!!
     dockerStart(containerName)
     Thread.sleep(6000)
   }

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkSqlServerTest.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkSqlServerTest.scala
@@ -1,32 +1,32 @@
-//package e2e.autoincrementingpk
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//class AutoIncrementingPkSqlServerTest extends AbstractSqlServerEndToEndTest with AutoIncrementingPkTestCases {
-//  override val originPort = 5556
-//  override val programArgs = Array(
-//    "--schemas", "dbo",
-//
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 2 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 4 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 6 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 8 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 10 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 12 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 14 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 16 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 18 ::: includeChildren",
-//    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 20 ::: includeChildren",
-//
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 2 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 4 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 6 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 8 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 10 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 12 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 14 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 16 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 18 ::: includeChildren",
-//    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 20 ::: includeChildren"
-//  )
-//}
+package e2e.autoincrementingpk
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class AutoIncrementingPkSqlServerTest extends AbstractSqlServerEndToEndTest with AutoIncrementingPkTestCases {
+  override val originPort = 5556
+  override val programArgs = Array(
+    "--schemas", "dbo",
+
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 2 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 4 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 6 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 8 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 10 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 12 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 14 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 16 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 18 ::: includeChildren",
+    "--baseQuery", "dbo.autoincrementing_pk_table ::: id = 20 ::: includeChildren",
+
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 2 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 4 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 6 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 8 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 10 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 12 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 14 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 16 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 18 ::: includeChildren",
+    "--baseQuery", "dbo.other_autoincrementing_pk_table ::: id = 20 ::: includeChildren"
+  )
+}

--- a/src/test/scala/e2e/basequeries/BaseQueriesSqlServerTest.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesSqlServerTest.scala
@@ -1,11 +1,11 @@
-//package e2e.basequeries
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//class BaseQueriesSqlServerTest extends AbstractSqlServerEndToEndTest with BaseQueriesTestCases {
-//  override val originPort = 5516
-//  override val programArgs = Array(
-//    "--schemas", "dbo",
-//    "--baseQuery", "dbo.base_table ::: 1 = 1 ::: excludeChildren"
-//  )
-//}
+package e2e.basequeries
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class BaseQueriesSqlServerTest extends AbstractSqlServerEndToEndTest with BaseQueriesTestCases {
+  override val originPort = 5516
+  override val programArgs = Array(
+    "--schemas", "dbo",
+    "--baseQuery", "dbo.base_table ::: 1 = 1 ::: excludeChildren"
+  )
+}

--- a/src/test/scala/e2e/circulardep/CircularDepDML.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepDML.scala
@@ -8,11 +8,11 @@ class CircularDepDML(val profile: JdbcProfile) extends CircularDepDDL {
 
   def dbioSeq = {
     val insertStatements = Seq(
-      Grandparents ++= (0 to 1000).map(i => GrandparentsRow(i, None)),
-      Parents ++= (0 to 10009).map(i => ParentsRow(i, i / 10)),
-      Children ++= (0 to 50049).map(i => ChildrenRow(i, i / 5))
+      Grandparents ++= (0 to 10).map(i => GrandparentsRow(i, None)),
+      Parents ++= (0 to 109).map(i => ParentsRow(i, i / 10)),
+      Children ++= (0 to 549).map(i => ChildrenRow(i, i / 5))
     )
-    val updateStatements = (0 to 1000 by 3).map { i =>
+    val updateStatements = (0 to 10 by 3).map { i =>
       Grandparents.filter(_.id === i).map(_.favoriteParentId).update(Some(i * 10))
     }
     val allStatements = insertStatements ++ updateStatements

--- a/src/test/scala/e2e/circulardep/CircularDepSqlServerTest.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepSqlServerTest.scala
@@ -1,12 +1,12 @@
-//package e2e.circulardep
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//class CircularDepSqlServerTest extends AbstractSqlServerEndToEndTest with CircularDepTestCases {
-//  override val originPort = 5486
-//  override val programArgs = Array(
-//    "--schemas", "dbo",
-//    "--baseQuery", "dbo.grandparents ::: id % 6 = 0 ::: includeChildren",
-//    "--skipPkStore", "dbo.children"
-//  )
-//}
+package e2e.circulardep
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class CircularDepSqlServerTest extends AbstractSqlServerEndToEndTest with CircularDepTestCases {
+  override val originPort = 5486
+  override val programArgs = Array(
+    "--schemas", "dbo",
+    "--baseQuery", "dbo.grandparents ::: id % 6 = 0 ::: includeChildren",
+    "--skipPkStore", "dbo.children"
+  )
+}

--- a/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
@@ -14,11 +14,11 @@ trait CircularDepTestCases extends AbstractEndToEndTest with CircularDepDDL with
   override lazy val dml = new CircularDepDML(profile).dbioSeq
 
   test("Correct number of grandparents were included") {
-    assertCount(Grandparents, 167)
+    assertCount(Grandparents, 2)
   }
 
   test("All grandparents have correct number of parents") {
-    (0 to 1000 by 6).foreach { i =>
+    (0 to 10 by 6).foreach { i =>
       assert(Await.result(targetDbSt.run(Parents.filter(_.grandparentId === i).size.result), Duration.Inf) === 10)
       assert(Await.result(targetDbAs.run(Parents.filter(_.grandparentId === i).size.result), Duration.Inf) === 10)
     }

--- a/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
@@ -1,20 +1,20 @@
-//package e2e.crossschema
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//import scala.sys.process._
-//
-//class CrossSchemaSqlServerTest extends AbstractSqlServerEndToEndTest with CrossSchemaTestCases {
-//  override val originPort = 5546
-//  override val programArgs = Array(
-//    "--schemas", "schema_1, schema_2, schema_3",
-//    "--baseQuery", "schema_1.schema_1_table ::: id = 2 ::: includeChildren"
-//  )
-//
-//  override def setupOriginDDL(): Unit = {
-//    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_1".!!
-//    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_2".!!
-//    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_3".!!
-//    super.setupOriginDDL()
-//  }
-//}
+package e2e.crossschema
+
+import e2e.AbstractSqlServerEndToEndTest
+
+import scala.sys.process._
+
+class CrossSchemaSqlServerTest extends AbstractSqlServerEndToEndTest with CrossSchemaTestCases {
+  override val originPort = 5546
+  override val programArgs = Array(
+    "--schemas", "schema_1, schema_2, schema_3",
+    "--baseQuery", "schema_1.schema_1_table ::: id = 2 ::: includeChildren"
+  )
+
+  override def setupOriginDDL(): Unit = {
+    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_1".!!
+    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_2".!!
+    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_3".!!
+    super.setupOriginDDL()
+  }
+}

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkSqlServerTest.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkSqlServerTest.scala
@@ -1,12 +1,12 @@
-//package e2e.fkreferencenonpk
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//class FkReferenceNonPkSqlServerTest extends AbstractSqlServerEndToEndTest with FkReferenceNonPkTestCases {
-//  override val originPort = 5566
-//  override val programArgs = Array(
-//    "--schemas", "dbo",
-//    "--baseQuery", "dbo.referenced_table ::: id in (1, 4) ::: includeChildren",
-//    "--baseQuery", "dbo.referencing_table ::: id = 5 ::: includeChildren"
-//  )
-//}
+package e2e.fkreferencenonpk
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class FkReferenceNonPkSqlServerTest extends AbstractSqlServerEndToEndTest with FkReferenceNonPkTestCases {
+  override val originPort = 5566
+  override val programArgs = Array(
+    "--schemas", "dbo",
+    "--baseQuery", "dbo.referenced_table ::: id in (1, 4) ::: includeChildren",
+    "--baseQuery", "dbo.referencing_table ::: id = 5 ::: includeChildren"
+  )
+}

--- a/src/test/scala/e2e/missingfk/MissingFkSqlServerTest.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkSqlServerTest.scala
@@ -1,13 +1,13 @@
-//package e2e.missingfk
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//class MissingFkSqlServerTest extends AbstractSqlServerEndToEndTest with MissingFkTestCases {
-//  override val originPort = 5496
-//  override val programArgs = Array(
-//    "--schemas", "dbo",
-//    "--baseQuery", "dbo.table_1 ::: id = 2 ::: includeChildren",
-//    "--foreignKey", "dbo.table_2(table_1_id) ::: dbo.table_1(id)",
-//    "--primaryKey", "dbo.table_4(table_1_id, table_3_id)"
-//  )
-//}
+package e2e.missingfk
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class MissingFkSqlServerTest extends AbstractSqlServerEndToEndTest with MissingFkTestCases {
+  override val originPort = 5496
+  override val programArgs = Array(
+    "--schemas", "dbo",
+    "--baseQuery", "dbo.table_1 ::: id = 2 ::: includeChildren",
+    "--foreignKey", "dbo.table_2(table_1_id) ::: dbo.table_1(id)",
+    "--primaryKey", "dbo.table_4(table_1_id, table_3_id)"
+  )
+}

--- a/src/test/scala/e2e/mixedcase/MixedCaseSqlServerTest.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseSqlServerTest.scala
@@ -1,13 +1,13 @@
-//package e2e.mixedcase
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//class MixedCaseSqlServerTest extends AbstractSqlServerEndToEndTest with MixedCaseTestCases {
-//  override val originPort = 5536
-//  override val programArgs = Array(
-//    "--schemas", "dbo",
-//    "--baseQuery", "dbo.mixed_CASE_table_1 ::: [ID] = 2 ::: includeChildren",
-//    "--skipPkStore", "dbo.mixed_CASE_table_1",
-//    "--skipPkStore", "dbo.mixed_CASE_table_2"
-//  )
-//}
+package e2e.mixedcase
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class MixedCaseSqlServerTest extends AbstractSqlServerEndToEndTest with MixedCaseTestCases {
+  override val originPort = 5536
+  override val programArgs = Array(
+    "--schemas", "dbo",
+    "--baseQuery", "dbo.mixed_CASE_table_1 ::: [ID] = 2 ::: includeChildren",
+    "--skipPkStore", "dbo.mixed_CASE_table_1",
+    "--skipPkStore", "dbo.mixed_CASE_table_2"
+  )
+}

--- a/src/test/scala/e2e/pktypes/PkTypesSqlServerTest.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesSqlServerTest.scala
@@ -1,27 +1,27 @@
-//package e2e.pktypes
-//
-//import java.util.UUID
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//class PkTypesSqlServerTest extends AbstractSqlServerEndToEndTest with PkTypesTestCases {
-//  override val originPort = 5576
-//
-//  override def expectedByteIds = super.expectedByteIds.filterNot(_ == -128)
-//
-//  override def expectedUUIDs: Seq[UUID] = super.expectedUUIDs.reverse
-//
-//  override def expectedReferencingTableIds: Seq[Int] = super.expectedReferencingTableIds.filterNot(_ == 1)
-//
-//  override val programArgs = Array(
-//    "--schemas", "dbo",
-//    "--baseQuery", "dbo.byte_pks ::: id = -128 ::: includeChildren",
-//    "--baseQuery", "dbo.short_pks ::: id = -32768 ::: includeChildren",
-//    "--baseQuery", "dbo.int_pks ::: id = -2147483648 ::: includeChildren",
-//    "--baseQuery", "dbo.long_pks ::: id = -9223372036854775808 ::: includeChildren",
-//    "--baseQuery", "dbo.uuid_pks ::: id = 'E6532CAE-F2BE-CB42-AAF7-3BDD58B0B645' ::: includeChildren",
-//    "--baseQuery", "dbo.char_10_pks ::: id = 'two' ::: includeChildren",
-//    "--baseQuery", "dbo.varchar_10_pks ::: id = 'six ' ::: includeChildren",
-//    "--baseQuery", "dbo.referencing_table ::: id in (3, 4, 7, 8, 11, 12, 15, 16, 18, 21, 24) ::: includeChildren"
-//  )
-//}
+package e2e.pktypes
+
+import java.util.UUID
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class PkTypesSqlServerTest extends AbstractSqlServerEndToEndTest with PkTypesTestCases {
+  override val originPort = 5576
+
+  override def expectedByteIds = super.expectedByteIds.filterNot(_ == -128)
+
+  override def expectedUUIDs: Seq[UUID] = super.expectedUUIDs.reverse
+
+  override def expectedReferencingTableIds: Seq[Int] = super.expectedReferencingTableIds.filterNot(_ == 1)
+
+  override val programArgs = Array(
+    "--schemas", "dbo",
+    "--baseQuery", "dbo.byte_pks ::: id = -128 ::: includeChildren",
+    "--baseQuery", "dbo.short_pks ::: id = -32768 ::: includeChildren",
+    "--baseQuery", "dbo.int_pks ::: id = -2147483648 ::: includeChildren",
+    "--baseQuery", "dbo.long_pks ::: id = -9223372036854775808 ::: includeChildren",
+    "--baseQuery", "dbo.uuid_pks ::: id = 'E6532CAE-F2BE-CB42-AAF7-3BDD58B0B645' ::: includeChildren",
+    "--baseQuery", "dbo.char_10_pks ::: id = 'two' ::: includeChildren",
+    "--baseQuery", "dbo.varchar_10_pks ::: id = 'six ' ::: includeChildren",
+    "--baseQuery", "dbo.referencing_table ::: id in (3, 4, 7, 8, 11, 12, 15, 16, 18, 21, 24) ::: includeChildren"
+  )
+}

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingSqlServerTest.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingSqlServerTest.scala
@@ -1,11 +1,11 @@
-//package e2e.selfreferencing
-//
-//import e2e.AbstractSqlServerEndToEndTest
-//
-//class SelfReferencingSqlServerTest extends AbstractSqlServerEndToEndTest with SelfReferencingTestCases {
-//  override val originPort = 5526
-//  override val programArgs = Array(
-//    "--schemas", "dbo",
-//    "--baseQuery", "dbo.self_referencing_table ::: id in (1, 3, 13, 14, 15) ::: includeChildren"
-//  )
-//}
+package e2e.selfreferencing
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class SelfReferencingSqlServerTest extends AbstractSqlServerEndToEndTest with SelfReferencingTestCases {
+  override val originPort = 5526
+  override val programArgs = Array(
+    "--schemas", "dbo",
+    "--baseQuery", "dbo.self_referencing_table ::: id in (1, 3, 13, 14, 15) ::: includeChildren"
+  )
+}


### PR DESCRIPTION
In 2017, the linux SQL Server docker container was unstable. Now that the default docker storage driver appears to be overlay2 (as opposed to aufs), these instability issues seem to have gone away :crossed_fingers:. Re-enabling the SQL Server tests as a result.

See:
https://github.com/Microsoft/mssql-docker/issues/171
https://github.com/Microsoft/mssql-docker/issues/181