### PR TITLE
Extract container start and rm away from AbstractEndToEndTest.scala

### DIFF
--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -11,7 +11,6 @@ import trw.dbsubsetter.{ApplicationAkkaStreams, ApplicationSingleThreaded}
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
-import scala.sys.process._
 
 abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
   //
@@ -122,12 +121,4 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
   }
 
   protected def createDockerContainers(): Unit
-
-  protected def dockerRm(name: String): Unit = {
-    s"docker rm --force --volumes $name".!
-  }
-
-  protected def dockerStart(name: String): Unit = {
-    s"docker start $name".!
-  }
 }

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -1,5 +1,7 @@
 package e2e
 
+import util.docker.ContainerUtil
+
 import scala.sys.process._
 
 abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
@@ -28,9 +30,9 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
 
   override protected def createDockerContainers(): Unit = {
     def createAndStart(name: String, port: Int): Unit = {
-      dockerRm(name)
+      ContainerUtil.rm(name)
       s"docker create --name $name -p $port:3306 --env MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.0.3".!!
-      dockerStart(name)
+      ContainerUtil.start(name)
     }
 
     createAndStart(originContainerName, originPort)
@@ -43,8 +45,8 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    dockerRm(originContainerName)
-    dockerRm(targetSithContainerName)
-    dockerRm(targetAkstContainerName)
+    ContainerUtil.rm(originContainerName)
+    ContainerUtil.rm(targetSithContainerName)
+    ContainerUtil.rm(targetAkstContainerName)
   }
 }

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -1,5 +1,7 @@
 package e2e
 
+import util.docker.ContainerUtil
+
 import scala.sys.process._
 
 abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
@@ -31,9 +33,9 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
 
   override protected def createDockerContainers(): Unit = {
     def createAndStart(name: String, port: Int): Unit = {
-      dockerRm(name)
+      ContainerUtil.rm(name)
       s"docker create --name $name -p $port:5432 postgres:9.6.3".!!
-      dockerStart(name)
+      ContainerUtil.start(name)
     }
 
     createAndStart(originContainerName, originPort)
@@ -48,8 +50,8 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    dockerRm(originContainerName)
-    dockerRm(targetSingleThreadedContainerName)
-    dockerRm(targetAkkaStreamsContainerName)
+    ContainerUtil.rm(originContainerName)
+    ContainerUtil.rm(targetSingleThreadedContainerName)
+    ContainerUtil.rm(targetAkkaStreamsContainerName)
   }
 }

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -1,5 +1,7 @@
 package e2e
 
+import util.docker.ContainerUtil
+
 import scala.sys.process._
 
 abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
@@ -28,14 +30,14 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
   }
 
   override protected def createDockerContainers(): Unit = {
-    dockerRm(containerName)
+    ContainerUtil.rm(containerName)
     s"docker create --name $containerName -p $originPort:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU12 /opt/mssql/bin/sqlservr".!!
-    dockerStart(containerName)
+    ContainerUtil.start(containerName)
     Thread.sleep(6000)
   }
 
   override protected def afterAll(): Unit = {
     super.afterAll()
-    dockerRm(containerName)
+    ContainerUtil.rm(containerName)
   }
 }

--- a/src/test/scala/util/docker/ContainerUtil.scala
+++ b/src/test/scala/util/docker/ContainerUtil.scala
@@ -1,0 +1,13 @@
+package util.docker
+
+import scala.sys.process._
+
+object ContainerUtil {
+  def rm(containerName: String): Unit = {
+    s"docker rm --force --volumes $containerName'".!
+  }
+
+  def start(containerName: String): Unit = {
+    s"docker start $containerName".!
+  }
+}

--- a/src/test/scala/util/docker/ContainerUtil.scala
+++ b/src/test/scala/util/docker/ContainerUtil.scala
@@ -4,7 +4,7 @@ import scala.sys.process._
 
 object ContainerUtil {
   def rm(containerName: String): Unit = {
-    s"docker rm --force --volumes $containerName'".!
+    s"docker rm --force --volumes $containerName".!
   }
 
   def start(containerName: String): Unit = {


### PR DESCRIPTION
Part 1 of a refactoring effort to make our testing infrastructure simpler and easier to work with in the future. Removes docker start and docker rm features from the AbstractEndToEndTest.scala superclass in order to chip away at some of the things this class, which is somewhat of a God Object, does.