### PR TITLE
Try to extract assertion utils out of AbstractEndToEndTest

### DIFF
--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -1,9 +1,7 @@
 package e2e
 
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
-import slick.dbio.{DBIOAction, Effect}
 import slick.jdbc.JdbcBackend
-import slick.lifted.{AbstractTable, TableQuery}
 import trw.dbsubsetter.config.{CommandLineParser, Config}
 import trw.dbsubsetter.db.{SchemaInfo, SchemaInfoRetrieval}
 import trw.dbsubsetter.workflow.BaseQueries
@@ -23,6 +21,8 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
   protected def makeConnStr(port: Int, dbName: String): String
 
   protected def programArgs: Array[String]
+
+  protected def createDockerContainers(): Unit
 
   protected def setupOriginDb(): Unit
 
@@ -97,28 +97,4 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
     targetDbSt.close()
     targetDbAs.close()
   }
-
-  protected def assertCount[T <: AbstractTable[_]](tq: TableQuery[T], expected: Long): Unit = {
-    import profile.api._
-    assert(Await.result(targetDbSt.run(tq.size.result), Duration.Inf) === expected)
-    assert(Await.result(targetDbAs.run(tq.size.result), Duration.Inf) === expected)
-  }
-
-  // Helper to get around intelliJ warnings, technically it could compile just with the Long version
-  protected def assertThat(action: DBIOAction[Option[Int], profile.api.NoStream, Effect.Read], expected: Long): Unit = {
-    assert(Await.result(targetDbSt.run(action), Duration.Inf) === Some(expected))
-    assert(Await.result(targetDbAs.run(action), Duration.Inf) === Some(expected))
-  }
-
-  protected def assertResult[T](action: DBIOAction[T, profile.api.NoStream, Effect.Read], expected: T): Unit = {
-    assert(Await.result(targetDbSt.run(action), Duration.Inf) === expected)
-    assert(Await.result(targetDbAs.run(action), Duration.Inf) === expected)
-  }
-
-  protected def assertThatLong(action: DBIOAction[Option[Long], profile.api.NoStream, Effect.Read], expected: Long): Unit = {
-    assert(Await.result(targetDbSt.run(action), Duration.Inf) === Some(expected))
-    assert(Await.result(targetDbAs.run(action), Duration.Inf) === Some(expected))
-  }
-
-  protected def createDockerContainers(): Unit
 }

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestCases.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestCases.scala
@@ -1,8 +1,9 @@
 package e2e.autoincrementingpk
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
+import util.assertion.AssertionUtil
 
-trait AutoIncrementingPkTestCases extends AbstractEndToEndTest with AutoIncrementingPkDDL with SlickSetup {
+trait AutoIncrementingPkTestCases extends AbstractEndToEndTest with AutoIncrementingPkDDL with SlickSetup with AssertionUtil {
   val dataSetName = "autoincrementing_pk"
 
   import profile.api._

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestCases.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestCases.scala
@@ -1,8 +1,9 @@
 package e2e.basequeries
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
+import util.assertion.AssertionUtil
 
-trait BaseQueriesTestCases extends AbstractEndToEndTest with BaseQueriesDDL with SlickSetup {
+trait BaseQueriesTestCases extends AbstractEndToEndTest with BaseQueriesDDL with SlickSetup with AssertionUtil {
   import profile.api._
 
   override val ddl = schema.create

--- a/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
@@ -1,11 +1,12 @@
 package e2e.circulardep
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
+import util.assertion.AssertionUtil
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-trait CircularDepTestCases extends AbstractEndToEndTest with CircularDepDDL with SlickSetup {
+trait CircularDepTestCases extends AbstractEndToEndTest with CircularDepDDL with SlickSetup with AssertionUtil {
   val dataSetName = "circular_dep"
 
   import profile.api._

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
@@ -2,8 +2,9 @@ package e2e.crossschema
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
 import trw.dbsubsetter.db.Table
+import util.assertion.AssertionUtil
 
-trait CrossSchemaTestCases extends AbstractEndToEndTest with CrossSchemaDDL with SlickSetup {
+trait CrossSchemaTestCases extends AbstractEndToEndTest with CrossSchemaDDL with SlickSetup with AssertionUtil {
   val dataSetName = "cross_schema"
 
   import profile.api._

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkTestCases.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkTestCases.scala
@@ -1,8 +1,9 @@
 package e2e.fkreferencenonpk
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
+import util.assertion.AssertionUtil
 
-trait FkReferenceNonPkTestCases extends AbstractEndToEndTest with FkReferenceNonPkDDL with SlickSetup {
+trait FkReferenceNonPkTestCases extends AbstractEndToEndTest with FkReferenceNonPkDDL with SlickSetup with AssertionUtil {
 
   import profile.api._
 

--- a/src/test/scala/e2e/missingfk/MissingFkTestCases.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestCases.scala
@@ -1,8 +1,9 @@
 package e2e.missingfk
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
+import util.assertion.AssertionUtil
 
-trait MissingFkTestCases extends AbstractEndToEndTest with MissingFkDDL with SlickSetup {
+trait MissingFkTestCases extends AbstractEndToEndTest with MissingFkDDL with SlickSetup with AssertionUtil {
   import profile.api._
 
   override val ddl = schema.create

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestCases.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestCases.scala
@@ -1,8 +1,9 @@
 package e2e.mixedcase
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
+import util.assertion.AssertionUtil
 
-trait MixedCaseTestCases extends AbstractEndToEndTest with MixedCaseDDL with SlickSetup {
+trait MixedCaseTestCases extends AbstractEndToEndTest with MixedCaseDDL with SlickSetup with AssertionUtil {
   val dataSetName = "mIXED_case_DB"
 
   import profile.api._

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
@@ -3,10 +3,11 @@ package e2e.mysqldatatypes
 import java.io.File
 
 import e2e.AbstractMysqlEndToEndTest
+import util.assertion.AssertionUtil
 
 import scala.sys.process._
 
-class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest {
+class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest with AssertionUtil {
   override val dataSetName = "mysql_data_types"
   override val originPort = 5580
 

--- a/src/test/scala/e2e/pktypes/PkTypesTestCases.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestCases.scala
@@ -3,8 +3,9 @@ package e2e.pktypes
 import java.util.UUID
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
+import util.assertion.AssertionUtil
 
-trait PkTypesTestCases extends AbstractEndToEndTest with PkTypesDDL with SlickSetup {
+trait PkTypesTestCases extends AbstractEndToEndTest with PkTypesDDL with SlickSetup with AssertionUtil {
   val dataSetName = "pk_types"
 
   import profile.api._

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestCases.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestCases.scala
@@ -1,8 +1,9 @@
 package e2e.selfreferencing
 
 import e2e.{AbstractEndToEndTest, SlickSetup}
+import util.assertion.AssertionUtil
 
-trait SelfReferencingTestCases extends AbstractEndToEndTest with SelfReferencingDDL with SlickSetup {
+trait SelfReferencingTestCases extends AbstractEndToEndTest with SelfReferencingDDL with SlickSetup with AssertionUtil {
   val dataSetName = "self_referencing"
 
   import profile.api._

--- a/src/test/scala/load/physics/PhysicsTestCases.scala
+++ b/src/test/scala/load/physics/PhysicsTestCases.scala
@@ -1,11 +1,12 @@
 package load.physics
 
 import e2e.{AbstractEndToEndTest, SlickSetupDDL}
+import util.assertion.AssertionUtil
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
-trait PhysicsTestCases extends AbstractEndToEndTest with PhysicsDDL with SlickSetupDDL {
+trait PhysicsTestCases extends AbstractEndToEndTest with PhysicsDDL with SlickSetupDDL with AssertionUtil {
 
   import profile.api._
 

--- a/src/test/scala/load/schooldb/SchoolDbTestCases.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestCases.scala
@@ -1,11 +1,12 @@
 package load.schooldb
 
 import e2e.{AbstractEndToEndTest, SlickSetupDDL}
+import util.assertion.AssertionUtil
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-trait SchoolDbTestCases extends AbstractEndToEndTest with SchoolDbDDL with SlickSetupDDL {
+trait SchoolDbTestCases extends AbstractEndToEndTest with SchoolDbDDL with SlickSetupDDL with AssertionUtil {
 
   import profile.api._
 

--- a/src/test/scala/util/assertion/AssertionUtil.scala
+++ b/src/test/scala/util/assertion/AssertionUtil.scala
@@ -1,0 +1,38 @@
+package util.assertion
+
+import org.scalatest.Assertions
+import slick.dbio.{DBIOAction, Effect}
+import slick.jdbc.JdbcBackend
+import slick.lifted.{AbstractTable, TableQuery}
+
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+trait AssertionUtil extends Assertions {
+
+  val profile: slick.jdbc.JdbcProfile
+  def targetDbSt: JdbcBackend#DatabaseDef
+  def targetDbAs: JdbcBackend#DatabaseDef
+
+  final def assertCount[T <: AbstractTable[_]](tq: TableQuery[T], expected: Long): Unit = {
+    import profile.api._
+    assert(Await.result(targetDbSt.run(tq.size.result), Duration.Inf) === expected)
+    assert(Await.result(targetDbAs.run(tq.size.result), Duration.Inf) === expected)
+  }
+
+  // Helper to get around intelliJ warnings, technically it could compile just with the Long version
+  final def assertThat(action: DBIOAction[Option[Int], profile.api.NoStream, Effect.Read], expected: Long): Unit = {
+    assert(Await.result(targetDbSt.run(action), Duration.Inf) === Some(expected))
+    assert(Await.result(targetDbAs.run(action), Duration.Inf) === Some(expected))
+  }
+
+  final def assertResult[T](action: DBIOAction[T, profile.api.NoStream, Effect.Read], expected: T): Unit = {
+    assert(Await.result(targetDbSt.run(action), Duration.Inf) === expected)
+    assert(Await.result(targetDbAs.run(action), Duration.Inf) === expected)
+  }
+
+  final def assertThatLong(action: DBIOAction[Option[Long], profile.api.NoStream, Effect.Read], expected: Long): Unit = {
+    assert(Await.result(targetDbSt.run(action), Duration.Inf) === Some(expected))
+    assert(Await.result(targetDbAs.run(action), Duration.Inf) === Some(expected))
+  }
+}


### PR DESCRIPTION
Part 2 of a refactoring effort to make our testing infrastructure simpler and easier to work with in the future. Continue extracting things from AbstractEndToEndTest, to try to reduce its large footprint. This time, extract all assertion-related utility functions from the class and place them in a separate utils class.