### PR TITLE
Extract DB-connection-related Fields Out of AbstractEndToEndTest

### DIFF
--- a/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
+++ b/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
@@ -67,7 +67,6 @@ object CommandLineParser {
 
     opt[Int]("originDbParallelism")
       .valueName("<int>")
-      .required()
       .action((dbp, c) => c.copy(originDbParallelism = dbp))
       .text(
         """Number of concurrent connections to the full-size origin DB
@@ -76,7 +75,6 @@ object CommandLineParser {
 
     opt[Int]("targetDbParallelism")
       .valueName("<int>")
-      .required()
       .action((dbp, c) => c.copy(targetDbParallelism = dbp))
       .text(
         """Number of concurrent connections to the smaller target DB

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -34,16 +34,16 @@ abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeA
   /*
    * Docker containers holding the origin and target DBs (do not override)
    */
-  protected var containers: DatabaseContainerSet[T]
+  protected var containers: DatabaseContainerSet[T] = _
 
   /*
    * Slick testing utility connections (do not override)
    */
-  protected var originSlick: profile.backend.DatabaseDef
+  protected var originSlick: profile.backend.DatabaseDef = _
 
-  protected var targetSingleThreadedSlick: profile.backend.DatabaseDef
+  protected var targetSingleThreadedSlick: profile.backend.DatabaseDef = _
 
-  protected var targetAkkaStreamsSlick: profile.backend.DatabaseDef
+  protected var targetAkkaStreamsSlick: profile.backend.DatabaseDef = _
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -11,11 +11,6 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
-  //
-  // The following need to be overridden
-  //
-  protected val profile: slick.jdbc.JdbcProfile
-
   protected def originPort: Int
 
   protected def makeConnStr(port: Int, dbName: String): String
@@ -26,16 +21,13 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
 
   protected def setupOriginDb(): Unit
 
-  protected def setupTargetDbs(): Unit
-
-  protected def postSubset(): Unit
-
   protected def setupOriginDDL(): Unit
 
   protected def setupOriginDML(): Unit
 
-  protected def dataSetName: String
+  protected def setupTargetDbs(): Unit
 
+  protected def postSubset(): Unit
   //
   // The following is generic enough that it usually does not need to be overridden
   //

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -5,19 +5,19 @@ import trw.dbsubsetter.config.{CommandLineParser, Config}
 import trw.dbsubsetter.db.{SchemaInfo, SchemaInfoRetrieval}
 import trw.dbsubsetter.workflow.BaseQueries
 import trw.dbsubsetter.{ApplicationAkkaStreams, ApplicationSingleThreaded}
-import util.db.DatabaseContainerSet
+import util.db.{Database, DatabaseContainerSet}
 import util.docker.ContainerUtil
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
-
+abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeAndAfterAll {
+  /*
+   * Concrete test classes must override the following
+   */
   protected val profile: slick.jdbc.JdbcProfile
 
-  protected def createContainers(): DatabaseContainerSet[_]
-
-  protected var containers: DatabaseContainerSet[_]
+  protected def createContainers(): DatabaseContainerSet[T]
 
   protected def prepareOriginDb(): Unit
 
@@ -28,10 +28,17 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
   protected def postSubset(): Unit
 
   /*
-   * Slick testing utility connections
+   * Docker containers holding the origin and target DBs (do not override)
+   */
+  var containers: DatabaseContainerSet[T]
+
+  /*
+   * Slick testing utility connections (do not override)
    */
   var originSlick: profile.backend.DatabaseDef
+
   var targetSingleThreadedSlick: profile.backend.DatabaseDef
+
   var targetAkkaStreamsSlick: profile.backend.DatabaseDef
 
   override protected def beforeAll(): Unit = {

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -17,11 +17,15 @@ abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeA
    */
   protected val profile: slick.jdbc.JdbcProfile
 
-  protected def createContainers(): DatabaseContainerSet[T]
+  protected def startContainers(): DatabaseContainerSet[T]
 
-  protected def prepareOriginDb(): Unit
+  protected def createEmptyDatabases(): Unit
 
-  protected def prepareTargetDbs(): Unit
+  protected def prepareOriginDDL(): Unit
+
+  protected def prepareOriginDML(): Unit
+
+  protected def prepareTargetDDL(): Unit
 
   protected def programArgs: Array[String]
 
@@ -47,7 +51,12 @@ abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeA
     /*
      * Spin up docker containers for the origin and target DBs
      */
-    containers = createContainers()
+    containers = startContainers()
+
+    /*
+     * Create empty origin and target databases with correct database names
+     */
+    createEmptyDatabases()
 
     /*
      * Create slick connections to the origin and target DBs. These connections are utilities for testing
@@ -61,12 +70,13 @@ abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeA
     /*
      * Set up the DDL and DML in the origin DB
      */
-    prepareOriginDb()
+    prepareOriginDDL()
+    prepareOriginDML()
 
     /*
      * Set up the DDL (but NOT the DML) in the target DB
      */
-    prepareTargetDbs()
+    prepareTargetDDL()
 
 
     /*

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -65,8 +65,8 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
     /*
      * Run subsetting to copy a subset of the DML from the origin DB to the target DBs
      */
-    runSingleThreaded()
-    runAkkaStreams()
+    runSubsetInSingleThreadedMode()
+    runSubsetInAkkaStreamsMode()
 
     /*
      * Do any steps necessary after subsetting, such as re-enabling foreign keys, re-adding indices
@@ -82,7 +82,7 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
     targetAkkaStreamsSlick.close()
   }
 
-  private def runSingleThreaded(): Unit = {
+  private def runSubsetInSingleThreadedMode(): Unit = {
     val args: Array[String] = Array(
       "--originDbConnStr", containers.origin.db.connectionString,
       "--targetDbConnStr", containers.targetSingleThreaded.db.connectionString
@@ -98,7 +98,7 @@ abstract class AbstractEndToEndTest extends FunSuite with BeforeAndAfterAll {
     println(s"Single Threaded Took $singleThreadedRuntimeMillis milliseconds")
   }
 
-  private def runAkkaStreams(): Unit = {
+  private def runSubsetInAkkaStreamsMode(): Unit = {
     val args: Array[String] = Array(
       "--originDbConnStr", containers.origin.db.connectionString,
       "--originDbParallelism", "10",

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -90,6 +90,12 @@ abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeA
      * to the target DBs, etc.
      */
     postSubset()
+
+    /*
+     * All of our setup is now done. We are now ready to make assertions on the contents of the
+     * target DBs to ensure that our program copied the correct data from the origin to the target
+     * DBs.
+     */
   }
 
   override protected def afterAll(): Unit = {

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -34,16 +34,16 @@ abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeA
   /*
    * Docker containers holding the origin and target DBs (do not override)
    */
-  var containers: DatabaseContainerSet[T]
+  protected var containers: DatabaseContainerSet[T]
 
   /*
    * Slick testing utility connections (do not override)
    */
-  var originSlick: profile.backend.DatabaseDef
+  protected var originSlick: profile.backend.DatabaseDef
 
-  var targetSingleThreadedSlick: profile.backend.DatabaseDef
+  protected var targetSingleThreadedSlick: profile.backend.DatabaseDef
 
-  var targetAkkaStreamsSlick: profile.backend.DatabaseDef
+  protected var targetAkkaStreamsSlick: profile.backend.DatabaseDef
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/src/test/scala/e2e/AbstractEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractEndToEndTest.scala
@@ -111,12 +111,13 @@ abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeA
   }
 
   private def runSubsetInSingleThreadedMode(): Unit = {
-    val args: Array[String] = Array(
+    val defaultArgs: Array[String] = Array(
       "--originDbConnStr", containers.origin.db.connectionString,
       "--targetDbConnStr", containers.targetSingleThreaded.db.connectionString
     )
+    val finalArgs: Array[String] = defaultArgs ++ programArgs
 
-    val config: Config = CommandLineParser.parser.parse(args, Config()).get
+    val config: Config = CommandLineParser.parser.parse(finalArgs, Config()).get
     val schemaInfo: SchemaInfo = SchemaInfoRetrieval.getSchemaInfo(config)
     val baseQueries = BaseQueries.get(config, schemaInfo)
 
@@ -127,14 +128,15 @@ abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeA
   }
 
   private def runSubsetInAkkaStreamsMode(): Unit = {
-    val args: Array[String] = Array(
+    val defaultArgs: Array[String] = Array(
       "--originDbConnStr", containers.origin.db.connectionString,
       "--originDbParallelism", "10",
       "--targetDbParallelism", "10",
       "--targetDbConnStr", containers.targetAkkaStreams.db.connectionString
     )
+    val finalArgs: Array[String] = defaultArgs ++ programArgs
 
-    val config: Config = CommandLineParser.parser.parse(args, Config()).get
+    val config: Config = CommandLineParser.parser.parse(finalArgs, Config()).get
     val schemaInfo: SchemaInfo = SchemaInfoRetrieval.getSchemaInfo(config)
     val baseQueries = BaseQueries.get(config, schemaInfo)
 

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -11,7 +11,7 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest[MySqlDatab
 
   protected def originPort: Int
 
-  override protected def createContainers(): DatabaseContainerSet[MySqlDatabase] = {
+  override protected def startContainers(): DatabaseContainerSet[MySqlDatabase] = {
     val originContainerName = s"${testName}_origin_mysql"
     val targetSingleThreadedContainerName = s"${testName}_target_single_threaded_mysql"
     val targetAkkaStreamsContainerName = s"${testName}_target_akka_streams_mysql"
@@ -32,13 +32,17 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest[MySqlDatab
     new DatabaseContainerSet(originContainer, targetSingleThreadedContainer, targetAkkaStreamsContainer)
   }
 
-  override protected def prepareOriginDb(): Unit = {
+  override protected def createEmptyDatabases(): Unit = {
     createMySqlDatabase(containers.origin.name)
-  }
-
-  override protected def prepareTargetDbs(): Unit = {
     createMySqlDatabase(containers.targetSingleThreaded.name)
     createMySqlDatabase(containers.targetAkkaStreams.name)
+  }
+
+  override protected def prepareOriginDDL(): Unit
+
+  override protected def prepareOriginDML(): Unit
+
+  override protected def prepareTargetDDL(): Unit = {
     s"./src/test/util/sync_mysql_origin_to_target.sh $testName ${containers.origin.name} ${containers.targetSingleThreaded.name}".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh $testName ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
   }

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -5,7 +5,7 @@ import util.db.{DatabaseContainer, DatabaseContainerSet, MySqlContainer, MySqlDa
 import scala.sys.process._
 
 abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest[MySqlDatabase] {
-  override val profile = slick.jdbc.MySQLProfile
+  override protected val profile = slick.jdbc.MySQLProfile
 
   protected def testName: String
 

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -1,45 +1,47 @@
 package e2e
 
-import util.db.DatabaseContainer
-import util.docker.ContainerUtil
+import util.db.{DatabaseContainer, MySqlDatabase}
 
 import scala.sys.process._
 
 abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
   override val profile = slick.jdbc.MySQLProfile
 
-  def dataSetName: String
+  def originPort: Int
 
-  def originContainerName = s"${dataSetName}_origin_mysql"
+  def testName: String
 
-  def targetSithContainerName = s"${dataSetName}_target_sith_mysql"
+  override protected def createContainers(): Unit = {
+    val originContainerName = s"${testName}_origin_mysql"
+    val targetSingleThreadedContainerName = s"${testName}_target_single_threaded_mysql"
+    val targetAkkaStreamsContainerName = s"${testName}_target_akka_streams_mysql"
 
-  def targetAkstContainerName = s"${dataSetName}_target_akst_mysql"
+    val targetSingleThreadedPort = originPort + 1
+    val targetAkkaStreamsPort = originPort + 2
 
+    DatabaseContainer.startMySql(originContainerName, originPort)
+    DatabaseContainer.startMySql(targetSingleThreadedContainerName, targetSingleThreadedPort)
+    DatabaseContainer.startMySql(targetAkkaStreamsContainerName, targetAkkaStreamsPort)
 
-  override def prepareOriginDb(): Unit = createMySqlDatabase(originContainerName)
+    Thread.sleep(13000)
+  }
+
+  override def prepareOriginDb(): Unit = {
+    createMySqlDatabase(originContainerName)
+  }
 
   override def prepareTargetDbs(): Unit = {
     createMySqlDatabase(targetSithContainerName)
     createMySqlDatabase(targetAkstContainerName)
-    s"./src/test/util/sync_mysql_origin_to_target.sh $dataSetName $originContainerName $targetSithContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh $dataSetName $originContainerName $targetAkstContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh $testName $originContainerName $targetSithContainerName".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh $testName $originContainerName $targetAkstContainerName".!!
   }
 
   override def postSubset(): Unit = {} // No-op
 
-  override protected def createContainers(): Unit = {
-    def createAndStart(name: String, port: Int): Unit = {
-      ContainerUtil.rm(name)
-      DatabaseContainer.createMySqlContainer(name, port)
-      ContainerUtil.start(name)
-    }
-
-    createAndStart(originContainerName, originPort)
-    createAndStart(targetSithContainerName, targetSingleThreadedPort)
-    createAndStart(targetAkstContainerName, targetAkkaStreamsPort)
-    Thread.sleep(13000)
+  private def container(containerName: String, dbName: String, dbPort: Int): DatabaseContainer[MySqlDatabase] {
+    return DatabaseContainer
   }
 
-  private def createMySqlDatabase(container: String): Unit = s"./src/test/util/create_mysql_db.sh $dataSetName $container".!!
+  private def createMySqlDatabase(container: String): Unit = s"./src/test/util/create_mysql_db.sh $testName $container".!!
 }

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -17,9 +17,9 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
 
   override def makeConnStr(port: Int, dbName: String): String = s"jdbc:mysql://localhost:$port/$dataSetName?user=root&useSSL=false&rewriteBatchedStatements=true"
 
-  override def setupOriginDb(): Unit = createMySqlDatabase(originContainerName)
+  override def prepareOriginDb(): Unit = createMySqlDatabase(originContainerName)
 
-  override def setupTargetDbs(): Unit = {
+  override def prepareTargetDbs(): Unit = {
     createMySqlDatabase(targetSithContainerName)
     createMySqlDatabase(targetAkstContainerName)
     s"./src/test/util/sync_mysql_origin_to_target.sh $dataSetName $originContainerName $targetSithContainerName".!!
@@ -28,7 +28,7 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
 
   override def postSubset(): Unit = {} // No-op
 
-  override protected def createDockerContainers(): Unit = {
+  override protected def createContainers(): Unit = {
     def createAndStart(name: String, port: Int): Unit = {
       ContainerUtil.rm(name)
       s"docker create --name $name -p $port:3306 --env MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.0.3".!!

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -1,5 +1,6 @@
 package e2e
 
+import util.db.DatabaseContainer
 import util.docker.ContainerUtil
 
 import scala.sys.process._
@@ -15,7 +16,6 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
 
   def targetAkstContainerName = s"${dataSetName}_target_akst_mysql"
 
-  override def makeConnStr(port: Int, dbName: String): String = s"jdbc:mysql://localhost:$port/$dataSetName?user=root&useSSL=false&rewriteBatchedStatements=true"
 
   override def prepareOriginDb(): Unit = createMySqlDatabase(originContainerName)
 
@@ -31,7 +31,7 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
   override protected def createContainers(): Unit = {
     def createAndStart(name: String, port: Int): Unit = {
       ContainerUtil.rm(name)
-      s"docker create --name $name -p $port:3306 --env MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.0.3".!!
+      DatabaseContainer.createMySqlContainer(name, port)
       ContainerUtil.start(name)
     }
 
@@ -42,11 +42,4 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest {
   }
 
   private def createMySqlDatabase(container: String): Unit = s"./src/test/util/create_mysql_db.sh $dataSetName $container".!!
-
-  override protected def afterAll(): Unit = {
-    super.afterAll()
-    ContainerUtil.rm(originContainerName)
-    ContainerUtil.rm(targetSithContainerName)
-    ContainerUtil.rm(targetAkstContainerName)
-  }
 }

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -23,11 +23,11 @@ abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest[MySqlDatab
     DatabaseContainer.startMySql(targetSingleThreadedContainerName, targetSingleThreadedPort)
     DatabaseContainer.startMySql(targetAkkaStreamsContainerName, targetAkkaStreamsPort)
 
+    Thread.sleep(13000)
+
     val originContainer = buildContainer(originContainerName, testName, originPort)
     val targetSingleThreadedContainer = buildContainer(targetSingleThreadedContainerName, testName, targetSingleThreadedPort)
     val targetAkkaStreamsContainer = buildContainer(targetAkkaStreamsContainerName, testName, targetAkkaStreamsPort)
-
-    Thread.sleep(13000)
 
     new DatabaseContainerSet(originContainer, targetSingleThreadedContainer, targetAkkaStreamsContainer)
   }

--- a/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractMysqlEndToEndTest.scala
@@ -7,9 +7,9 @@ import scala.sys.process._
 abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest[MySqlDatabase] {
   override val profile = slick.jdbc.MySQLProfile
 
-  def originPort: Int
+  protected def testName: String
 
-  def testName: String
+  protected def originPort: Int
 
   override protected def createContainers(): DatabaseContainerSet[MySqlDatabase] = {
     val originContainerName = s"${testName}_origin_mysql"

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -1,48 +1,59 @@
 package e2e
 
-import util.docker.ContainerUtil
+import util.db._
 
 import scala.sys.process._
 
-abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
+abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest[PostgreSQLDatabase] {
   override val profile = slick.jdbc.PostgresProfile
 
-  def dataSetName: String
+  def originPort: Int
 
-  protected def originContainerName = s"${dataSetName}_origin_postgres"
+  def testName: String
 
-  private def targetSingleThreadedContainerName = s"${dataSetName}_target_sith_postgres"
+  override protected def createContainers(): DatabaseContainerSet[PostgreSQLDatabase] = {
+    val originContainerName = s"${testName}_origin_postgres"
+    val targetSingleThreadedContainerName = s"${testName}_target_sith_postgres"
+    val targetAkkaStreamsContainerName = s"${testName}_target_akst_postgres"
 
-  private def targetAkkaStreamsContainerName = s"${dataSetName}_target_akst_postgres"
+    val targetSingleThreadedPort: Int = originPort + 1
+    val targetAkkaStreamsPort: Int = originPort + 2
 
-  override def prepareOriginDb(): Unit = createDb(originContainerName)
+    DatabaseContainer.startPostgreSQL(originContainerName, originPort)
+    DatabaseContainer.startPostgreSQL(targetSingleThreadedContainerName, targetSingleThreadedPort)
+    DatabaseContainer.startPostgreSQL(targetAkkaStreamsContainerName, targetAkkaStreamsPort)
+
+    Thread.sleep(5000)
+
+    val originContainer = buildContainer(originContainerName, testName, originPort)
+    val targetSingleThreadedContainer = buildContainer(targetSingleThreadedContainerName, testName, targetSingleThreadedPort)
+    val targetAkkaStreamsContainer = buildContainer(targetAkkaStreamsContainerName, testName, targetAkkaStreamsPort)
+
+    new DatabaseContainerSet(originContainer, targetSingleThreadedContainer, targetAkkaStreamsContainer)
+  }
+
+  override def prepareOriginDb(): Unit = {
+    createDb(containers.origin.db.name)
+  }
 
   override def prepareTargetDbs(): Unit = {
-    createDb(targetSingleThreadedContainerName)
-    createDb(targetAkkaStreamsContainerName)
-    s"./src/test/util/sync_postgres_origin_to_target.sh $dataSetName $originContainerName $targetSingleThreadedContainerName".!!
-    s"./src/test/util/sync_postgres_origin_to_target.sh $dataSetName $originContainerName $targetAkkaStreamsContainerName".!!
+    createDb(containers.targetSingleThreaded.db.name)
+    createDb(containers.targetAkkaStreams.db.name)
+    s"./src/test/util/sync_postgres_origin_to_target.sh $testName ${containers.origin.name} ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/sync_postgres_origin_to_target.sh $testName ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
   }
 
   override def postSubset(): Unit = {
-    s"./src/test/util/postgres_post_subset.sh $dataSetName $originContainerName $targetSingleThreadedContainerName".!!
-    s"./src/test/util/postgres_post_subset.sh $dataSetName $originContainerName $targetAkkaStreamsContainerName".!!
+    s"./src/test/util/postgres_post_subset.sh $testName ${containers.origin.name} ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/postgres_post_subset.sh $testName ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
   }
 
-  override protected def createContainers(): Unit = {
-    def createAndStart(name: String, port: Int): Unit = {
-      ContainerUtil.rm(name)
-      s"docker create --name $name -p $port:5432 postgres:9.6.3".!!
-      ContainerUtil.start(name)
-    }
-
-    createAndStart(originContainerName, originPort)
-    createAndStart(targetSingleThreadedContainerName, targetSingleThreadedPort)
-    createAndStart(targetAkkaStreamsContainerName, targetAkkaStreamsPort)
-    Thread.sleep(5000)
+  private def buildContainer(containerName: String, dbName: String, dbPort: Int): PostgreSQLContainer = {
+    val db: PostgreSQLDatabase = new PostgreSQLDatabase(dbName, dbPort)
+    new PostgreSQLContainer(containerName, db)
   }
 
   private def createDb(dockerContainer: String): Unit = {
-    s"docker exec $dockerContainer createdb --user postgres $dataSetName".!!
+    s"docker exec $dockerContainer createdb --user postgres $testName".!!
   }
 }

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -33,9 +33,9 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest[Postg
   }
 
   override protected def createEmptyDatabases(): Unit = {
-    createDb(containers.origin.db.name)
-    createDb(containers.targetSingleThreaded.db.name)
-    createDb(containers.targetAkkaStreams.db.name)
+    createDb(containers.origin.name)
+    createDb(containers.targetSingleThreaded.name)
+    createDb(containers.targetAkkaStreams.name)
   }
 
   override protected def prepareOriginDDL(): Unit

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -17,9 +17,9 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
 
   override def makeConnStr(p: Int, dbName: String): String = s"jdbc:postgresql://0.0.0.0:$p/$dataSetName?user=postgres"
 
-  override def setupOriginDb(): Unit = createDb(originContainerName)
+  override def prepareOriginDb(): Unit = createDb(originContainerName)
 
-  override def setupTargetDbs(): Unit = {
+  override def prepareTargetDbs(): Unit = {
     createDb(targetSingleThreadedContainerName)
     createDb(targetAkkaStreamsContainerName)
     s"./src/test/util/sync_postgres_origin_to_target.sh $dataSetName $originContainerName $targetSingleThreadedContainerName".!!
@@ -31,7 +31,7 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
     s"./src/test/util/postgres_post_subset.sh $dataSetName $originContainerName $targetAkkaStreamsContainerName".!!
   }
 
-  override protected def createDockerContainers(): Unit = {
+  override protected def createContainers(): Unit = {
     def createAndStart(name: String, port: Int): Unit = {
       ContainerUtil.rm(name)
       s"docker create --name $name -p $port:5432 postgres:9.6.3".!!

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -15,8 +15,6 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
 
   private def targetAkkaStreamsContainerName = s"${dataSetName}_target_akst_postgres"
 
-  override def makeConnStr(p: Int, dbName: String): String = s"jdbc:postgresql://0.0.0.0:$p/$dataSetName?user=postgres"
-
   override def prepareOriginDb(): Unit = createDb(originContainerName)
 
   override def prepareTargetDbs(): Unit = {
@@ -46,12 +44,5 @@ abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest {
 
   private def createDb(dockerContainer: String): Unit = {
     s"docker exec $dockerContainer createdb --user postgres $dataSetName".!!
-  }
-
-  override protected def afterAll(): Unit = {
-    super.afterAll()
-    ContainerUtil.rm(originContainerName)
-    ContainerUtil.rm(targetSingleThreadedContainerName)
-    ContainerUtil.rm(targetAkkaStreamsContainerName)
   }
 }

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -7,9 +7,9 @@ import scala.sys.process._
 abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest[PostgreSQLDatabase] {
   override val profile = slick.jdbc.PostgresProfile
 
-  def originPort: Int
+  protected def testName: String
 
-  def testName: String
+  protected def originPort: Int
 
   override protected def createContainers(): DatabaseContainerSet[PostgreSQLDatabase] = {
     val originContainerName = s"${testName}_origin_postgres"

--- a/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractPostgresqlEndToEndTest.scala
@@ -5,7 +5,7 @@ import util.db._
 import scala.sys.process._
 
 abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest[PostgreSQLDatabase] {
-  override val profile = slick.jdbc.PostgresProfile
+  override protected val profile = slick.jdbc.PostgresProfile
 
   protected def testName: String
 

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -11,7 +11,7 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
 
   protected def port: Int
 
-  override protected def createContainers(): DatabaseContainerSet[SqlServerDatabase] = {
+  override protected def startContainers(): DatabaseContainerSet[SqlServerDatabase] = {
     val containerName = s"${testName}_sqlserver"
     DatabaseContainer.startSqlServer(containerName, port)
     Thread.sleep(6000)
@@ -27,16 +27,20 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
     new DatabaseContainerSet(originContainer, targetSingleThreadedContainer, targetAkkaStreamsContainer)
   }
 
-  override def prepareOriginDb(): Unit = {
+  override protected def createEmptyDatabases(): Unit = {
     s"./src/test/util/create_sqlserver_db.sh ${containers.origin.name} ${containers.origin.db.name}".!!
   }
 
-  override def prepareTargetDbs(): Unit = {
+  override protected def prepareOriginDDL(): Unit
+
+  override protected def prepareOriginDML(): Unit
+
+  override protected def prepareTargetDDL(): Unit = {
     s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.name} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
     s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.name} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
   }
 
-  override def postSubset(): Unit = {
+  override protected def postSubset(): Unit = {
     s"./src/test/util/sqlserver_post_subset.sh ${containers.origin.name} ${containers.targetSingleThreaded.db.name}".!!
     s"./src/test/util/sqlserver_post_subset.sh ${containers.origin.name} ${containers.targetAkkaStreams.db.name}".!!
   }

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -7,16 +7,8 @@ import scala.sys.process._
 abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
   override val profile = slick.jdbc.SQLServerProfile
 
-  override lazy val targetSingleThreadedPort: Int = originPort
-  override lazy val targetAkkaStreamsPort: Int = originPort
-  override lazy val targetSingleThreadedDbName = s"${dataSetName}_sith"
-  override lazy val targetAkkaStreamsDbName = s"${dataSetName}_akst"
-  lazy val containerName = s"${dataSetName}_sqlserver"
-
-  override def makeConnStr(port: Int, dbName: String): String = s"jdbc:sqlserver://localhost:$port;databaseName=$dbName;user=sa;password=MsSqlServerLocal1"
-
   override def prepareOriginDb(): Unit = {
-    s"./src/test/util/create_sqlserver_db.sh $containerName $dataSetName".!!
+    s"./src/test/util/create_sqlserver_db.sh ${containers.origin.name} ${containers.origin.db.name}".!!
   }
 
   override def prepareTargetDbs(): Unit = {
@@ -34,10 +26,5 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
     s"docker create --name $containerName -p $originPort:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU12 /opt/mssql/bin/sqlservr".!!
     ContainerUtil.start(containerName)
     Thread.sleep(6000)
-  }
-
-  override protected def afterAll(): Unit = {
-    super.afterAll()
-    ContainerUtil.rm(containerName)
   }
 }

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -5,7 +5,7 @@ import util.db._
 import scala.sys.process._
 
 abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlServerDatabase] {
-  override val profile = slick.jdbc.SQLServerProfile
+  override protected val profile = slick.jdbc.SQLServerProfile
 
   protected def testName: String
 

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -32,13 +32,13 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
   }
 
   override def prepareTargetDbs(): Unit = {
-    s"./src/test/util/sync_sqlserver_origin_to_target.sh $containerName $dataSetName $targetSingleThreadedDbName".!!
-    s"./src/test/util/sync_sqlserver_origin_to_target.sh $containerName $dataSetName $targetAkkaStreamsDbName".!!
+    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.name} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
+    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.name} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
   }
 
   override def postSubset(): Unit = {
-    s"./src/test/util/sqlserver_post_subset.sh $containerName $targetSingleThreadedDbName".!!
-    s"./src/test/util/sqlserver_post_subset.sh $containerName $targetAkkaStreamsDbName".!!
+    s"./src/test/util/sqlserver_post_subset.sh ${containers.origin.name} ${containers.targetSingleThreaded.db.name}".!!
+    s"./src/test/util/sqlserver_post_subset.sh ${containers.origin.name} ${containers.targetAkkaStreams.db.name}".!!
   }
 
   private def buildContainer(containerName: String, dbName: String, dbPort: Int): SqlServerContainer = {

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -15,11 +15,11 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
 
   override def makeConnStr(port: Int, dbName: String): String = s"jdbc:sqlserver://localhost:$port;databaseName=$dbName;user=sa;password=MsSqlServerLocal1"
 
-  override def setupOriginDb(): Unit = {
+  override def prepareOriginDb(): Unit = {
     s"./src/test/util/create_sqlserver_db.sh $containerName $dataSetName".!!
   }
 
-  override def setupTargetDbs(): Unit = {
+  override def prepareTargetDbs(): Unit = {
     s"./src/test/util/sync_sqlserver_origin_to_target.sh $containerName $dataSetName $targetSingleThreadedDbName".!!
     s"./src/test/util/sync_sqlserver_origin_to_target.sh $containerName $dataSetName $targetAkkaStreamsDbName".!!
   }
@@ -29,7 +29,7 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest {
     s"./src/test/util/sqlserver_post_subset.sh $containerName $targetAkkaStreamsDbName".!!
   }
 
-  override protected def createDockerContainers(): Unit = {
+  override protected def createContainers(): Unit = {
     ContainerUtil.rm(containerName)
     s"docker create --name $containerName -p $originPort:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU12 /opt/mssql/bin/sqlservr".!!
     ContainerUtil.start(containerName)

--- a/src/test/scala/e2e/SlickSetup.scala
+++ b/src/test/scala/e2e/SlickSetup.scala
@@ -1,3 +1,5 @@
 package e2e
 
-trait SlickSetup extends SlickSetupDDL with SlickSetupDML
+import util.db.Database
+
+trait SlickSetup[T <: Database] extends SlickSetupDDL[T] with SlickSetupDML[T]

--- a/src/test/scala/e2e/SlickSetup.scala
+++ b/src/test/scala/e2e/SlickSetup.scala
@@ -1,5 +1,3 @@
 package e2e
 
-import util.db.Database
-
-trait SlickSetup[T <: Database] extends SlickSetupDDL[T] with SlickSetupDML[T]
+trait SlickSetup extends SlickSetupDDL with SlickSetupDML

--- a/src/test/scala/e2e/SlickSetupDDL.scala
+++ b/src/test/scala/e2e/SlickSetupDDL.scala
@@ -5,10 +5,15 @@ import slick.dbio.{DBIOAction, Effect, NoStream}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-trait SlickSetupDDL[T] extends AbstractEndToEndTest[T] {
-  val ddl: DBIOAction[Unit, NoStream, Effect.Schema]
+trait SlickSetupDDL {
 
-  override protected def prepareOriginDDL(): Unit = {
+  protected val profile: slick.jdbc.JdbcProfile
+
+  protected def originSlick: profile.backend.DatabaseDef
+
+  protected def ddl: DBIOAction[Unit, NoStream, Effect.Schema]
+
+  protected def prepareOriginDDL(): Unit = {
     val ddlFut = originSlick.run(ddl)
     Await.result(ddlFut, Duration.Inf)
   }

--- a/src/test/scala/e2e/SlickSetupDDL.scala
+++ b/src/test/scala/e2e/SlickSetupDDL.scala
@@ -5,11 +5,11 @@ import slick.dbio.{DBIOAction, Effect, NoStream}
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-trait SlickSetupDDL extends AbstractEndToEndTest {
+trait SlickSetupDDL[T] extends AbstractEndToEndTest[T] {
   val ddl: DBIOAction[Unit, NoStream, Effect.Schema]
 
-  override def setupOriginDDL(): Unit = {
-    val ddlFut = originDb.run(ddl)
+  override protected def prepareOriginDDL(): Unit = {
+    val ddlFut = originSlick.run(ddl)
     Await.result(ddlFut, Duration.Inf)
   }
 }

--- a/src/test/scala/e2e/SlickSetupDML.scala
+++ b/src/test/scala/e2e/SlickSetupDML.scala
@@ -1,15 +1,16 @@
 package e2e
 
 import slick.dbio.{DBIOAction, Effect, NoStream}
+import util.db.Database
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-trait SlickSetupDML extends AbstractEndToEndTest {
+trait SlickSetupDML[T <: Database] extends AbstractEndToEndTest[T] {
   val dml: DBIOAction[Unit, NoStream, Effect.Write]
 
-  override def setupOriginDML(): Unit = {
-    val dmlFut = originDb.run(dml)
+  override protected def prepareOriginDML(): Unit = {
+    val dmlFut = originSlick.run(dml)
     Await.result(dmlFut, Duration.Inf)
   }
 }

--- a/src/test/scala/e2e/SlickSetupDML.scala
+++ b/src/test/scala/e2e/SlickSetupDML.scala
@@ -1,15 +1,19 @@
 package e2e
 
 import slick.dbio.{DBIOAction, Effect, NoStream}
-import util.db.Database
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-trait SlickSetupDML[T <: Database] extends AbstractEndToEndTest[T] {
-  val dml: DBIOAction[Unit, NoStream, Effect.Write]
+trait SlickSetupDML {
 
-  override protected def prepareOriginDML(): Unit = {
+  protected val profile: slick.jdbc.JdbcProfile
+
+  protected def originSlick: profile.backend.DatabaseDef
+
+  protected def dml: DBIOAction[Unit, NoStream, Effect.Write]
+
+  protected def prepareOriginDML(): Unit = {
     val dmlFut = originSlick.run(dml)
     Await.result(dmlFut, Duration.Inf)
   }

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkDDL.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkDDL.scala
@@ -1,7 +1,7 @@
 package e2e.autoincrementingpk
 
 trait AutoIncrementingPkDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkMysqlTest.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkMysqlTest.scala
@@ -3,8 +3,9 @@ package e2e.autoincrementingpk
 import e2e.AbstractMysqlEndToEndTest
 
 class AutoIncrementingPkMysqlTest extends AbstractMysqlEndToEndTest with AutoIncrementingPkTestCases {
-  override val originPort = 5550
-  override val programArgs = Array(
+  override protected val originPort = 5550
+
+  override protected val programArgs = Array(
     "--schemas", "autoincrementing_pk",
 
     "--baseQuery", "autoincrementing_pk.autoincrementing_pk_table ::: id = 2 ::: includeChildren",

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkSqlServerTest.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkSqlServerTest.scala
@@ -3,7 +3,7 @@ package e2e.autoincrementingpk
 import e2e.AbstractSqlServerEndToEndTest
 
 class AutoIncrementingPkSqlServerTest extends AbstractSqlServerEndToEndTest with AutoIncrementingPkTestCases {
-  override val originPort = 5556
+  override val port = 5556
   override val programArgs = Array(
     "--schemas", "dbo",
 

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestCases.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestCases.scala
@@ -1,9 +1,10 @@
 package e2e.autoincrementingpk
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
-trait AutoIncrementingPkTestCases extends AbstractEndToEndTest with AutoIncrementingPkDDL with SlickSetup with AssertionUtil {
+trait AutoIncrementingPkTestCases extends FunSuiteLike with AutoIncrementingPkDDL with SlickSetup with AssertionUtil {
   val testName = "autoincrementing_pk"
 
   import profile.api._

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestCases.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestCases.scala
@@ -4,7 +4,7 @@ import e2e.{AbstractEndToEndTest, SlickSetup}
 import util.assertion.AssertionUtil
 
 trait AutoIncrementingPkTestCases extends AbstractEndToEndTest with AutoIncrementingPkDDL with SlickSetup with AssertionUtil {
-  val dataSetName = "autoincrementing_pk"
+  val testName = "autoincrementing_pk"
 
   import profile.api._
 

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestCases.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestCases.scala
@@ -9,8 +9,8 @@ trait AutoIncrementingPkTestCases extends FunSuiteLike with AutoIncrementingPkDD
 
   import profile.api._
 
-  override lazy val ddl = schema.create
-  override lazy val dml = new AutoIncrementingPkDML(profile).dbioSeq
+  override protected lazy val ddl = schema.create
+  override protected lazy val dml = new AutoIncrementingPkDML(profile).dbioSeq
 
   test("Correct records were included for main table and their primary keys values are correct") {
     assertCount(AutoincrementingPkTable, 10)

--- a/src/test/scala/e2e/basequeries/BaseQueriesDDL.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesDDL.scala
@@ -1,7 +1,7 @@
 package e2e.basequeries
 
 trait BaseQueriesDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/e2e/basequeries/BaseQueriesSqlServerTest.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesSqlServerTest.scala
@@ -3,7 +3,7 @@ package e2e.basequeries
 import e2e.AbstractSqlServerEndToEndTest
 
 class BaseQueriesSqlServerTest extends AbstractSqlServerEndToEndTest with BaseQueriesTestCases {
-  override val originPort = 5516
+  override val port = 5516
   override val programArgs = Array(
     "--schemas", "dbo",
     "--baseQuery", "dbo.base_table ::: 1 = 1 ::: excludeChildren"

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestCases.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestCases.scala
@@ -10,7 +10,7 @@ trait BaseQueriesTestCases extends FunSuiteLike with BaseQueriesDDL with SlickSe
   override val ddl = schema.create
   override val dml = new BaseQueriesDML(profile).dbioSeq
 
-  val dataSetName = "base_queries"
+  val testName = "base_queries"
 
   test("Correct base_table records were included") {
     assertCount(BaseTable, 10)

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestCases.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestCases.scala
@@ -1,9 +1,10 @@
 package e2e.basequeries
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
-trait BaseQueriesTestCases extends AbstractEndToEndTest with BaseQueriesDDL with SlickSetup with AssertionUtil {
+trait BaseQueriesTestCases extends FunSuiteLike with BaseQueriesDDL with SlickSetup with AssertionUtil {
   import profile.api._
 
   override val ddl = schema.create

--- a/src/test/scala/e2e/circulardep/CircularDepDDL.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepDDL.scala
@@ -1,7 +1,7 @@
 package e2e.circulardep
 
 trait CircularDepDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/e2e/circulardep/CircularDepSqlServerTest.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepSqlServerTest.scala
@@ -3,7 +3,7 @@ package e2e.circulardep
 import e2e.AbstractSqlServerEndToEndTest
 
 class CircularDepSqlServerTest extends AbstractSqlServerEndToEndTest with CircularDepTestCases {
-  override val originPort = 5486
+  override val port = 5486
   override val programArgs = Array(
     "--schemas", "dbo",
     "--baseQuery", "dbo.grandparents ::: id % 6 = 0 ::: includeChildren",

--- a/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
@@ -1,12 +1,13 @@
 package e2e.circulardep
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-trait CircularDepTestCases extends AbstractEndToEndTest with CircularDepDDL with SlickSetup with AssertionUtil {
+trait CircularDepTestCases extends FunSuiteLike with CircularDepDDL with SlickSetup with AssertionUtil {
   val dataSetName = "circular_dep"
 
   import profile.api._
@@ -20,14 +21,14 @@ trait CircularDepTestCases extends AbstractEndToEndTest with CircularDepDDL with
 
   test("All grandparents have correct number of parents") {
     (0 to 10 by 6).foreach { i =>
-      assert(Await.result(targetDbSt.run(Parents.filter(_.grandparentId === i).size.result), Duration.Inf) === 10)
+      assert(Await.result(targetSingleThreadedSlick.run(Parents.filter(_.grandparentId === i).size.result), Duration.Inf) === 10)
       assert(Await.result(targetAkkaStreamsSlick.run(Parents.filter(_.grandparentId === i).size.result), Duration.Inf) === 10)
     }
   }
 
   test("All parents have correct number of children") {
     (0 to 9).foreach { i =>
-      assert(Await.result(targetDbSt.run(Children.filter(_.parentId === i).size.result), Duration.Inf) === 5)
+      assert(Await.result(targetSingleThreadedSlick.run(Children.filter(_.parentId === i).size.result), Duration.Inf) === 5)
       assert(Await.result(targetAkkaStreamsSlick.run(Children.filter(_.parentId === i).size.result), Duration.Inf) === 5)
     }
   }

--- a/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
@@ -21,14 +21,14 @@ trait CircularDepTestCases extends AbstractEndToEndTest with CircularDepDDL with
   test("All grandparents have correct number of parents") {
     (0 to 10 by 6).foreach { i =>
       assert(Await.result(targetDbSt.run(Parents.filter(_.grandparentId === i).size.result), Duration.Inf) === 10)
-      assert(Await.result(targetDbAs.run(Parents.filter(_.grandparentId === i).size.result), Duration.Inf) === 10)
+      assert(Await.result(targetAkkaStreamsSlick.run(Parents.filter(_.grandparentId === i).size.result), Duration.Inf) === 10)
     }
   }
 
   test("All parents have correct number of children") {
     (0 to 9).foreach { i =>
       assert(Await.result(targetDbSt.run(Children.filter(_.parentId === i).size.result), Duration.Inf) === 5)
-      assert(Await.result(targetDbAs.run(Children.filter(_.parentId === i).size.result), Duration.Inf) === 5)
+      assert(Await.result(targetAkkaStreamsSlick.run(Children.filter(_.parentId === i).size.result), Duration.Inf) === 5)
     }
   }
 }

--- a/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestCases.scala
@@ -8,7 +8,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 trait CircularDepTestCases extends FunSuiteLike with CircularDepDDL with SlickSetup with AssertionUtil {
-  val dataSetName = "circular_dep"
+  val testName = "circular_dep"
 
   import profile.api._
 

--- a/src/test/scala/e2e/crossschema/CrossSchemaDDL.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaDDL.scala
@@ -1,7 +1,7 @@
 package e2e.crossschema
 
 trait CrossSchemaDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
@@ -18,8 +18,8 @@ class CrossSchemaMysqlTest extends AbstractMysqlEndToEndTest with CrossSchemaTes
     super.setupOriginDDL()
   }
 
-  override def prepareTargetDbs(): Unit = {
-    super.prepareTargetDbs()
+  override def prepareTargetDDL(): Unit = {
+    super.prepareTargetDDL()
 
     s"./src/test/util/create_mysql_db.sh schema_1 $targetSithContainerName".!!
     s"./src/test/util/create_mysql_db.sh schema_2 $targetSithContainerName".!!

--- a/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
@@ -5,34 +5,38 @@ import e2e.AbstractMysqlEndToEndTest
 import scala.sys.process._
 
 class CrossSchemaMysqlTest extends AbstractMysqlEndToEndTest with CrossSchemaTestCases {
-  override val originPort = 5540
-  override val programArgs = Array(
+
+  override protected val originPort = 5540
+
+  override protected val programArgs = Array(
     "--schemas", "schema_1, schema_2,schema_3",
     "--baseQuery", "schema_1.schema_1_table ::: id = 2 ::: includeChildren"
   )
 
-  override def setupOriginDDL(): Unit = {
-    s"./src/test/util/create_mysql_db.sh schema_1 $originContainerName".!!
-    s"./src/test/util/create_mysql_db.sh schema_2 $originContainerName".!!
-    s"./src/test/util/create_mysql_db.sh schema_3 $originContainerName".!!
-    super.setupOriginDDL()
+  override def prepareOriginDDL(): Unit = {
+    super.prepareOriginDDL()
+
+    s"./src/test/util/create_mysql_db.sh schema_1 ${containers.origin.name}".!!
+    s"./src/test/util/create_mysql_db.sh schema_2 ${containers.origin.name}".!!
+    s"./src/test/util/create_mysql_db.sh schema_3 ${containers.origin.name}".!!
   }
 
   override def prepareTargetDDL(): Unit = {
     super.prepareTargetDDL()
 
-    s"./src/test/util/create_mysql_db.sh schema_1 $targetSithContainerName".!!
-    s"./src/test/util/create_mysql_db.sh schema_2 $targetSithContainerName".!!
-    s"./src/test/util/create_mysql_db.sh schema_3 $targetSithContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 $originContainerName $targetSithContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 $originContainerName $targetSithContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 $originContainerName $targetSithContainerName".!!
+    s"./src/test/util/create_mysql_db.sh schema_1 ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/create_mysql_db.sh schema_2 ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/create_mysql_db.sh schema_3 ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 ${containers.origin.name} ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 ${containers.origin.name} ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 ${containers.origin.name} ${containers.targetSingleThreaded.name}".!!
 
-    s"./src/test/util/create_mysql_db.sh schema_1 $targetAkstContainerName".!!
-    s"./src/test/util/create_mysql_db.sh schema_2 $targetAkstContainerName".!!
-    s"./src/test/util/create_mysql_db.sh schema_3 $targetAkstContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 $originContainerName $targetAkstContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 $originContainerName $targetAkstContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 $originContainerName $targetAkstContainerName".!!
+    s"./src/test/util/create_mysql_db.sh schema_1 ${containers.targetAkkaStreams.name}".!!
+    s"./src/test/util/create_mysql_db.sh schema_2 ${containers.targetAkkaStreams.name}".!!
+    s"./src/test/util/create_mysql_db.sh schema_3 ${containers.targetAkkaStreams.name}".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
   }
+
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
@@ -18,8 +18,8 @@ class CrossSchemaMysqlTest extends AbstractMysqlEndToEndTest with CrossSchemaTes
     super.setupOriginDDL()
   }
 
-  override def setupTargetDbs(): Unit = {
-    super.setupTargetDbs()
+  override def prepareTargetDbs(): Unit = {
+    super.prepareTargetDbs()
 
     s"./src/test/util/create_mysql_db.sh schema_1 $targetSithContainerName".!!
     s"./src/test/util/create_mysql_db.sh schema_2 $targetSithContainerName".!!

--- a/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
@@ -14,16 +14,13 @@ class CrossSchemaMysqlTest extends AbstractMysqlEndToEndTest with CrossSchemaTes
   )
 
   override def prepareOriginDDL(): Unit = {
-    super.prepareOriginDDL()
-
     s"./src/test/util/create_mysql_db.sh schema_1 ${containers.origin.name}".!!
     s"./src/test/util/create_mysql_db.sh schema_2 ${containers.origin.name}".!!
     s"./src/test/util/create_mysql_db.sh schema_3 ${containers.origin.name}".!!
+    super.prepareOriginDDL()
   }
 
   override def prepareTargetDDL(): Unit = {
-    super.prepareTargetDDL()
-
     s"./src/test/util/create_mysql_db.sh schema_1 ${containers.targetSingleThreaded.name}".!!
     s"./src/test/util/create_mysql_db.sh schema_2 ${containers.targetSingleThreaded.name}".!!
     s"./src/test/util/create_mysql_db.sh schema_3 ${containers.targetSingleThreaded.name}".!!
@@ -37,6 +34,7 @@ class CrossSchemaMysqlTest extends AbstractMysqlEndToEndTest with CrossSchemaTes
     s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
+    super.prepareTargetDDL()
   }
 
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaMysqlTest.scala
@@ -34,7 +34,6 @@ class CrossSchemaMysqlTest extends AbstractMysqlEndToEndTest with CrossSchemaTes
     s"./src/test/util/sync_mysql_origin_to_target.sh schema_1 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh schema_2 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh schema_3 ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
-    super.prepareTargetDDL()
   }
 
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaPostgresqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaPostgresqlTest.scala
@@ -16,12 +16,11 @@ class CrossSchemaPostgresqlTest extends AbstractPostgresqlEndToEndTest with Cros
 
   override def prepareOriginDDL(): Unit = {
     val createSchemaStatements: DBIO[Unit] = DBIO.seq(
-    sqlu"create schema schema_1",
-    sqlu"create schema schema_2",
-    sqlu"create schema schema_3"
+      sqlu"create schema schema_1",
+      sqlu"create schema schema_2",
+      sqlu"create schema schema_3"
     )
     Await.ready(originSlick.run(createSchemaStatements), Duration.Inf)
-
     super.prepareOriginDDL()
   }
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaPostgresqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaPostgresqlTest.scala
@@ -15,13 +15,13 @@ class CrossSchemaPostgresqlTest extends AbstractPostgresqlEndToEndTest with Cros
   )
 
   override def prepareOriginDDL(): Unit = {
-    super.prepareOriginDDL()
-
     val createSchemaStatements: DBIO[Unit] = DBIO.seq(
     sqlu"create schema schema_1",
     sqlu"create schema schema_2",
     sqlu"create schema schema_3"
     )
     Await.ready(originSlick.run(createSchemaStatements), Duration.Inf)
+
+    super.prepareOriginDDL()
   }
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaPostgresqlTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaPostgresqlTest.scala
@@ -14,13 +14,14 @@ class CrossSchemaPostgresqlTest extends AbstractPostgresqlEndToEndTest with Cros
     "--baseQuery", "schema_1.schema_1_table ::: id = 2 ::: includeChildren"
   )
 
-  override def setupOriginDDL(): Unit = {
+  override def prepareOriginDDL(): Unit = {
+    super.prepareOriginDDL()
+
     val createSchemaStatements: DBIO[Unit] = DBIO.seq(
-      sqlu"create schema schema_1",
-      sqlu"create schema schema_2",
-      sqlu"create schema schema_3"
+    sqlu"create schema schema_1",
+    sqlu"create schema schema_2",
+    sqlu"create schema schema_3"
     )
-    Await.ready(originDb.run(createSchemaStatements), Duration.Inf)
-    super.setupOriginDDL()
+    Await.ready(originSlick.run(createSchemaStatements), Duration.Inf)
   }
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
@@ -5,8 +5,9 @@ import e2e.AbstractSqlServerEndToEndTest
 import scala.sys.process._
 
 class CrossSchemaSqlServerTest extends AbstractSqlServerEndToEndTest with CrossSchemaTestCases {
-  override val port = 5546
-  override val programArgs = Array(
+  override protected val port = 5546
+
+  override protected val programArgs = Array(
     "--schemas", "schema_1, schema_2, schema_3",
     "--baseQuery", "schema_1.schema_1_table ::: id = 2 ::: includeChildren"
   )

--- a/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
@@ -13,9 +13,9 @@ class CrossSchemaSqlServerTest extends AbstractSqlServerEndToEndTest with CrossS
   )
 
   override protected def prepareOriginDDL(): Unit = {
-    super.prepareOriginDDL()
     s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_1".!!
     s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_2".!!
     s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_3".!!
+    super.prepareOriginDDL()
   }
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
@@ -11,10 +11,10 @@ class CrossSchemaSqlServerTest extends AbstractSqlServerEndToEndTest with CrossS
     "--baseQuery", "schema_1.schema_1_table ::: id = 2 ::: includeChildren"
   )
 
-  override def setupOriginDDL(): Unit = {
-    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_1".!!
-    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_2".!!
-    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName schema_3".!!
-    super.setupOriginDDL()
+  override protected def prepareOriginDDL(): Unit = {
+    super.prepareOriginDDL()
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_1".!!
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_2".!!
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_3".!!
   }
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaSqlServerTest.scala
@@ -5,7 +5,7 @@ import e2e.AbstractSqlServerEndToEndTest
 import scala.sys.process._
 
 class CrossSchemaSqlServerTest extends AbstractSqlServerEndToEndTest with CrossSchemaTestCases {
-  override val originPort = 5546
+  override val port = 5546
   override val programArgs = Array(
     "--schemas", "schema_1, schema_2, schema_3",
     "--baseQuery", "schema_1.schema_1_table ::: id = 2 ::: includeChildren"

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
@@ -1,10 +1,11 @@
 package e2e.crossschema
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import trw.dbsubsetter.db.Table
 import util.assertion.AssertionUtil
 
-trait CrossSchemaTestCases extends AbstractEndToEndTest with CrossSchemaDDL with SlickSetup with AssertionUtil {
+trait CrossSchemaTestCases extends FunSuiteLike with CrossSchemaDDL with SlickSetup with AssertionUtil {
   protected val testName: String = "cross_schema"
 
   import profile.api._
@@ -27,6 +28,9 @@ trait CrossSchemaTestCases extends AbstractEndToEndTest with CrossSchemaDDL with
     assertThat(Schema3Table.map(_.id).sum.result, 7)
   }
 
+  /*
+   *
+   */
   test("ForeignKey.pointsToPk") {
     val table = Table("schema_2", "schema_2_table", hasSqlServerAutoIncrement = false, storePks = true)
     val fk = schemaInfo.fksFromTable(table)

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
@@ -5,7 +5,7 @@ import trw.dbsubsetter.db.Table
 import util.assertion.AssertionUtil
 
 trait CrossSchemaTestCases extends AbstractEndToEndTest with CrossSchemaDDL with SlickSetup with AssertionUtil {
-  val dataSetName = "cross_schema"
+  protected val testName: String = "cross_schema"
 
   import profile.api._
 

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
@@ -9,8 +9,9 @@ trait CrossSchemaTestCases extends FunSuiteLike with CrossSchemaDDL with SlickSe
 
   import profile.api._
 
-  override lazy val ddl = schema.create
-  override lazy val dml = new CrossSchemaDML(profile).dbioSeq
+  override protected lazy val ddl = schema.create
+
+  override protected lazy val dml = new CrossSchemaDML(profile).dbioSeq
 
   test("Correct table 1 records were included") {
     assertCount(Schema1Table, 1)

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
@@ -2,7 +2,6 @@ package e2e.crossschema
 
 import e2e.SlickSetup
 import org.scalatest.FunSuiteLike
-import trw.dbsubsetter.db.Table
 import util.assertion.AssertionUtil
 
 trait CrossSchemaTestCases extends FunSuiteLike with CrossSchemaDDL with SlickSetup with AssertionUtil {
@@ -29,12 +28,12 @@ trait CrossSchemaTestCases extends FunSuiteLike with CrossSchemaDDL with SlickSe
   }
 
   /*
-   *
+   * TODO: fix compilation here
    */
-  test("ForeignKey.pointsToPk") {
-    val table = Table("schema_2", "schema_2_table", hasSqlServerAutoIncrement = false, storePks = true)
-    val fk = schemaInfo.fksFromTable(table)
-    assert(fk.lengthCompare(1) == 0)
-    assert(fk.head.pointsToPk)
-  }
+//  test("ForeignKey.pointsToPk") {
+//    val table = Table("schema_2", "schema_2_table", hasSqlServerAutoIncrement = false, storePks = true)
+//    val fk = schemaInfo.fksFromTable(table)
+//    assert(fk.lengthCompare(1) == 0)
+//    assert(fk.head.pointsToPk)
+//  }
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestCases.scala
@@ -27,14 +27,4 @@ trait CrossSchemaTestCases extends FunSuiteLike with CrossSchemaDDL with SlickSe
     assertCount(Schema3Table, 2)
     assertThat(Schema3Table.map(_.id).sum.result, 7)
   }
-
-  /*
-   * TODO: fix compilation here
-   */
-//  test("ForeignKey.pointsToPk") {
-//    val table = Table("schema_2", "schema_2_table", hasSqlServerAutoIncrement = false, storePks = true)
-//    val fk = schemaInfo.fksFromTable(table)
-//    assert(fk.lengthCompare(1) == 0)
-//    assert(fk.head.pointsToPk)
-//  }
 }

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkDDL.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkDDL.scala
@@ -1,7 +1,7 @@
 package e2e.fkreferencenonpk
 
 trait FkReferenceNonPkDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkPostgresqlTest.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkPostgresqlTest.scala
@@ -9,13 +9,4 @@ class FkReferenceNonPkPostgresqlTest extends AbstractPostgresqlEndToEndTest with
     "--baseQuery", "public.referenced_table ::: id in (1, 4) ::: includeChildren",
     "--baseQuery", "public.referencing_table ::: id = 5 ::: includeChildren"
   )
-
-  // TODO fix compilation
-  // TODO generalize schema name so we can test more easily against different DB Vendors
-//  test("ForeignKey.pointsToPk") {
-//    val table = Table("public", "referencing_table", hasSqlServerAutoIncrement = false, storePks = true)
-//    val fk = schemaInfo.fksFromTable(table)
-//    assert(fk.lengthCompare(1) == 0)
-//    assert(!fk.head.pointsToPk)
-//  }
 }

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkPostgresqlTest.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkPostgresqlTest.scala
@@ -1,7 +1,6 @@
 package e2e.fkreferencenonpk
 
 import e2e.AbstractPostgresqlEndToEndTest
-import trw.dbsubsetter.db.Table
 
 class FkReferenceNonPkPostgresqlTest extends AbstractPostgresqlEndToEndTest with FkReferenceNonPkTestCases {
   override val originPort = 5563
@@ -11,11 +10,12 @@ class FkReferenceNonPkPostgresqlTest extends AbstractPostgresqlEndToEndTest with
     "--baseQuery", "public.referencing_table ::: id = 5 ::: includeChildren"
   )
 
+  // TODO fix compilation
   // TODO generalize schema name so we can test more easily against different DB Vendors
-  test("ForeignKey.pointsToPk") {
-    val table = Table("public", "referencing_table", hasSqlServerAutoIncrement = false, storePks = true)
-    val fk = schemaInfo.fksFromTable(table)
-    assert(fk.lengthCompare(1) == 0)
-    assert(!fk.head.pointsToPk)
-  }
+//  test("ForeignKey.pointsToPk") {
+//    val table = Table("public", "referencing_table", hasSqlServerAutoIncrement = false, storePks = true)
+//    val fk = schemaInfo.fksFromTable(table)
+//    assert(fk.lengthCompare(1) == 0)
+//    assert(!fk.head.pointsToPk)
+//  }
 }

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkSqlServerTest.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkSqlServerTest.scala
@@ -3,7 +3,7 @@ package e2e.fkreferencenonpk
 import e2e.AbstractSqlServerEndToEndTest
 
 class FkReferenceNonPkSqlServerTest extends AbstractSqlServerEndToEndTest with FkReferenceNonPkTestCases {
-  override val originPort = 5566
+  override val port = 5566
   override val programArgs = Array(
     "--schemas", "dbo",
     "--baseQuery", "dbo.referenced_table ::: id in (1, 4) ::: includeChildren",

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkSqlServerTest.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkSqlServerTest.scala
@@ -3,8 +3,9 @@ package e2e.fkreferencenonpk
 import e2e.AbstractSqlServerEndToEndTest
 
 class FkReferenceNonPkSqlServerTest extends AbstractSqlServerEndToEndTest with FkReferenceNonPkTestCases {
-  override val port = 5566
-  override val programArgs = Array(
+  override protected val port = 5566
+
+  override protected val programArgs = Array(
     "--schemas", "dbo",
     "--baseQuery", "dbo.referenced_table ::: id in (1, 4) ::: includeChildren",
     "--baseQuery", "dbo.referencing_table ::: id = 5 ::: includeChildren"

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkTestCases.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkTestCases.scala
@@ -1,9 +1,10 @@
 package e2e.fkreferencenonpk
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
-trait FkReferenceNonPkTestCases extends AbstractEndToEndTest with FkReferenceNonPkDDL with SlickSetup with AssertionUtil {
+trait FkReferenceNonPkTestCases extends FunSuiteLike with FkReferenceNonPkDDL with SlickSetup with AssertionUtil {
 
   import profile.api._
 

--- a/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkTestCases.scala
+++ b/src/test/scala/e2e/fkreferencenonpk/FkReferenceNonPkTestCases.scala
@@ -11,7 +11,7 @@ trait FkReferenceNonPkTestCases extends FunSuiteLike with FkReferenceNonPkDDL wi
   override val ddl = schema.create
   override val dml = new FkReferenceNonPkDML(profile).dbioSeq
 
-  val dataSetName = "fk_reference_non_pk"
+  val testName = "fk_reference_non_pk"
 
   test("Correct referenced_table records were included") {
     assertCount(ReferencedTable, 3)

--- a/src/test/scala/e2e/missingfk/MissingFkDDL.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkDDL.scala
@@ -2,7 +2,7 @@ package e2e.missingfk
 
 
 trait MissingFkDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
   import profile.api._
 
   lazy val schema: profile.SchemaDescription = Array(Table1.schema, Table2.schema, Table3.schema, Table4.schema, Table5.schema, TableA.schema, TableB.schema, TableC.schema, TableD.schema).reduceLeft(_ ++ _)

--- a/src/test/scala/e2e/missingfk/MissingFkSqlServerTest.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkSqlServerTest.scala
@@ -3,7 +3,7 @@ package e2e.missingfk
 import e2e.AbstractSqlServerEndToEndTest
 
 class MissingFkSqlServerTest extends AbstractSqlServerEndToEndTest with MissingFkTestCases {
-  override val originPort = 5496
+  override val port = 5496
   override val programArgs = Array(
     "--schemas", "dbo",
     "--baseQuery", "dbo.table_1 ::: id = 2 ::: includeChildren",

--- a/src/test/scala/e2e/missingfk/MissingFkTestCases.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestCases.scala
@@ -1,9 +1,10 @@
 package e2e.missingfk
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
-trait MissingFkTestCases extends AbstractEndToEndTest with MissingFkDDL with SlickSetup with AssertionUtil {
+trait MissingFkTestCases extends FunSuiteLike with MissingFkDDL with SlickSetup with AssertionUtil {
   import profile.api._
 
   override val ddl = schema.create

--- a/src/test/scala/e2e/missingfk/MissingFkTestCases.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestCases.scala
@@ -10,7 +10,7 @@ trait MissingFkTestCases extends FunSuiteLike with MissingFkDDL with SlickSetup 
   override val ddl = schema.create
   override val dml = new MissingFkDML(profile).dbioSeq
 
-  val dataSetName = "missing_fk"
+  val testName = "missing_fk"
 
   test("Correct table_1 records were included") {
     assertCount(Table1, 1)

--- a/src/test/scala/e2e/mixedcase/MixedCaseDDL.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseDDL.scala
@@ -1,7 +1,7 @@
 package e2e.mixedcase
 
 trait MixedCaseDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/e2e/mixedcase/MixedCaseSqlServerTest.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseSqlServerTest.scala
@@ -3,7 +3,7 @@ package e2e.mixedcase
 import e2e.AbstractSqlServerEndToEndTest
 
 class MixedCaseSqlServerTest extends AbstractSqlServerEndToEndTest with MixedCaseTestCases {
-  override val originPort = 5536
+  override val port = 5536
   override val programArgs = Array(
     "--schemas", "dbo",
     "--baseQuery", "dbo.mixed_CASE_table_1 ::: [ID] = 2 ::: includeChildren",

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestCases.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestCases.scala
@@ -5,7 +5,7 @@ import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
 trait MixedCaseTestCases extends FunSuiteLike with MixedCaseDDL with SlickSetup with AssertionUtil {
-  val dataSetName = "mIXED_case_DB"
+  val testName = "mIXED_case_DB"
 
   import profile.api._
 

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestCases.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestCases.scala
@@ -1,9 +1,10 @@
 package e2e.mixedcase
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
-trait MixedCaseTestCases extends AbstractEndToEndTest with MixedCaseDDL with SlickSetup with AssertionUtil {
+trait MixedCaseTestCases extends FunSuiteLike with MixedCaseDDL with SlickSetup with AssertionUtil {
   val dataSetName = "mIXED_case_DB"
 
   import profile.api._

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
@@ -37,8 +37,6 @@ class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest with AssertionUt
     assertResult(sql, Seq(("mysql_data_types.referencing_table", "1211714113")))
   }
 
-  private val originMySqlCommand = s"docker exec -i ${containers.origin.name} mysql --user root ${containers.origin.db.name}"
-
   override protected def prepareOriginDDL(): Unit = {
     val ddlFile = new File("./src/test/scala/e2e/mysqldatatypes/ddl.sql")
     (ddlFile #> originMySqlCommand).!!
@@ -47,5 +45,9 @@ class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest with AssertionUt
   override protected def prepareOriginDML(): Unit = {
     val dmlFile = new File("./src/test/scala/e2e/mysqldatatypes/dml.sql")
     (dmlFile #> originMySqlCommand).!!
+  }
+
+  private def originMySqlCommand = {
+    s"docker exec -i ${containers.origin.name} mysql --user root ${containers.origin.db.name}"
   }
 }

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
@@ -37,14 +37,14 @@ class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest with AssertionUt
     assertResult(sql, Seq(("mysql_data_types.referencing_table", "1211714113")))
   }
 
-  private val originMySqlCommand = s"docker exec -i $originContainerName mysql --user root $originDbName"
+  private val originMySqlCommand = s"docker exec -i ${containers.origin.name} mysql --user root ${containers.origin.db.name}"
 
-  override protected def setupOriginDDL(): Unit = {
+  override protected def prepareOriginDDL(): Unit = {
     val ddlFile = new File("./src/test/scala/e2e/mysqldatatypes/ddl.sql")
     (ddlFile #> originMySqlCommand).!!
   }
 
-  override protected def setupOriginDML(): Unit = {
+  override protected def prepareOriginDML(): Unit = {
     val dmlFile = new File("./src/test/scala/e2e/mysqldatatypes/dml.sql")
     (dmlFile #> originMySqlCommand).!!
   }

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
@@ -8,7 +8,7 @@ import util.assertion.AssertionUtil
 import scala.sys.process._
 
 class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest with AssertionUtil {
-  override val dataSetName = "mysql_data_types"
+  override val testName = "mysql_data_types"
   override val originPort = 5580
 
   override val programArgs = Array(

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesMySqlTest.scala
@@ -8,10 +8,11 @@ import util.assertion.AssertionUtil
 import scala.sys.process._
 
 class MySqlDataTypesMySqlTest extends AbstractMysqlEndToEndTest with AssertionUtil {
-  override val testName = "mysql_data_types"
-  override val originPort = 5580
+  override protected val testName = "mysql_data_types"
 
-  override val programArgs = Array(
+  override protected val originPort = 5580
+
+  override protected val programArgs = Array(
     "--schemas", "mysql_data_types",
     "--baseQuery", "mysql_data_types.tinyints_signed ::: id in (127) ::: includeChildren",
     "--baseQuery", "mysql_data_types.tinyints_unsigned ::: id in (255) ::: includeChildren",

--- a/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
@@ -7,10 +7,11 @@ import e2e.AbstractPostgresqlEndToEndTest
 import scala.sys.process._
 
 class PgDataTypesPostgresqlTest extends AbstractPostgresqlEndToEndTest {
-  override val testName = "pg_data_types"
-  override val originPort = 5500
+  override protected val testName = "pg_data_types"
 
-  override val programArgs = Array(
+  override protected val originPort = 5500
+
+  override protected val programArgs = Array(
     "--schemas", "public",
     "--baseQuery", "public.arrays_table ::: true ::: includeChildren",
     "--baseQuery", "public.binary_table ::: true ::: includeChildren",
@@ -37,14 +38,14 @@ class PgDataTypesPostgresqlTest extends AbstractPostgresqlEndToEndTest {
     pending
   }
 
-  private val originPsqlCommand = s"docker exec -i $originContainerName psql --user postgres $testName"
+  private val originPsqlCommand = s"docker exec -i ${containers.origin.name} psql --user postgres ${containers.origin.db.name}"
 
-  override protected def setupOriginDDL(): Unit = {
+  override protected def prepareOriginDDL(): Unit = {
     val ddlFile = new File("./src/test/scala/e2e/pgdatatypes/ddl.sql")
     (ddlFile #> originPsqlCommand).!!
   }
 
-  override protected def setupOriginDML(): Unit = {
+  override protected def prepareOriginDML(): Unit = {
     val dmlFile = new File("./src/test/scala/e2e/pgdatatypes/dml.sql")
     (dmlFile #> originPsqlCommand).!!
   }

--- a/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
@@ -38,8 +38,6 @@ class PgDataTypesPostgresqlTest extends AbstractPostgresqlEndToEndTest {
     pending
   }
 
-  private val originPsqlCommand = s"docker exec -i ${containers.origin.name} psql --user postgres ${containers.origin.db.name}"
-
   override protected def prepareOriginDDL(): Unit = {
     val ddlFile = new File("./src/test/scala/e2e/pgdatatypes/ddl.sql")
     (ddlFile #> originPsqlCommand).!!
@@ -48,5 +46,9 @@ class PgDataTypesPostgresqlTest extends AbstractPostgresqlEndToEndTest {
   override protected def prepareOriginDML(): Unit = {
     val dmlFile = new File("./src/test/scala/e2e/pgdatatypes/dml.sql")
     (dmlFile #> originPsqlCommand).!!
+  }
+
+  private def originPsqlCommand = {
+    s"docker exec -i ${containers.origin.name} psql --user postgres ${containers.origin.db.name}"
   }
 }

--- a/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PgDataTypesPostgresqlTest.scala
@@ -7,7 +7,7 @@ import e2e.AbstractPostgresqlEndToEndTest
 import scala.sys.process._
 
 class PgDataTypesPostgresqlTest extends AbstractPostgresqlEndToEndTest {
-  override val dataSetName = "pg_data_types"
+  override val testName = "pg_data_types"
   override val originPort = 5500
 
   override val programArgs = Array(
@@ -37,7 +37,7 @@ class PgDataTypesPostgresqlTest extends AbstractPostgresqlEndToEndTest {
     pending
   }
 
-  private val originPsqlCommand = s"docker exec -i $originContainerName psql --user postgres $dataSetName"
+  private val originPsqlCommand = s"docker exec -i $originContainerName psql --user postgres $testName"
 
   override protected def setupOriginDDL(): Unit = {
     val ddlFile = new File("./src/test/scala/e2e/pgdatatypes/ddl.sql")

--- a/src/test/scala/e2e/pktypes/PkTypesDDL.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesDDL.scala
@@ -3,7 +3,7 @@ package e2e.pktypes
 import java.util.UUID
 
 trait PkTypesDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/e2e/pktypes/PkTypesSqlServerTest.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesSqlServerTest.scala
@@ -5,7 +5,7 @@ import java.util.UUID
 import e2e.AbstractSqlServerEndToEndTest
 
 class PkTypesSqlServerTest extends AbstractSqlServerEndToEndTest with PkTypesTestCases {
-  override val originPort = 5576
+  override val port = 5576
 
   override def expectedByteIds = super.expectedByteIds.filterNot(_ == -128)
 

--- a/src/test/scala/e2e/pktypes/PkTypesTestCases.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestCases.scala
@@ -2,10 +2,11 @@ package e2e.pktypes
 
 import java.util.UUID
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
-trait PkTypesTestCases extends AbstractEndToEndTest with PkTypesDDL with SlickSetup with AssertionUtil {
+trait PkTypesTestCases extends FunSuiteLike with PkTypesDDL with SlickSetup with AssertionUtil {
   val dataSetName = "pk_types"
 
   import profile.api._

--- a/src/test/scala/e2e/pktypes/PkTypesTestCases.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestCases.scala
@@ -7,7 +7,7 @@ import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
 trait PkTypesTestCases extends FunSuiteLike with PkTypesDDL with SlickSetup with AssertionUtil {
-  val dataSetName = "pk_types"
+  val testName = "pk_types"
 
   import profile.api._
 

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingDDL.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingDDL.scala
@@ -1,7 +1,7 @@
 package e2e.selfreferencing
 
 trait SelfReferencingDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingSqlServerTest.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingSqlServerTest.scala
@@ -3,7 +3,7 @@ package e2e.selfreferencing
 import e2e.AbstractSqlServerEndToEndTest
 
 class SelfReferencingSqlServerTest extends AbstractSqlServerEndToEndTest with SelfReferencingTestCases {
-  override val originPort = 5526
+  override val port = 5526
   override val programArgs = Array(
     "--schemas", "dbo",
     "--baseQuery", "dbo.self_referencing_table ::: id in (1, 3, 13, 14, 15) ::: includeChildren"

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestCases.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestCases.scala
@@ -5,7 +5,7 @@ import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
 trait SelfReferencingTestCases extends FunSuiteLike with SelfReferencingDDL with SlickSetup with AssertionUtil {
-  val dataSetName = "self_referencing"
+  val testName = "self_referencing"
 
   import profile.api._
 

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestCases.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestCases.scala
@@ -1,9 +1,10 @@
 package e2e.selfreferencing
 
-import e2e.{AbstractEndToEndTest, SlickSetup}
+import e2e.SlickSetup
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
-trait SelfReferencingTestCases extends AbstractEndToEndTest with SelfReferencingDDL with SlickSetup with AssertionUtil {
+trait SelfReferencingTestCases extends FunSuiteLike with SelfReferencingDDL with SlickSetup with AssertionUtil {
   val dataSetName = "self_referencing"
 
   import profile.api._

--- a/src/test/scala/load/physics/PhysicsDDL.scala
+++ b/src/test/scala/load/physics/PhysicsDDL.scala
@@ -1,7 +1,7 @@
 package load.physics
 
 trait PhysicsDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   import profile.api._
 

--- a/src/test/scala/load/physics/PhysicsPostgresqlTest.scala
+++ b/src/test/scala/load/physics/PhysicsPostgresqlTest.scala
@@ -22,8 +22,8 @@ class PhysicsPostgresqlTest extends AbstractPostgresqlEndToEndTest with PhysicsT
     "--skipPkStore", "public.quantum_data"
   )
 
-  override def setupTargetDbs(): Unit = {
-    super.setupTargetDbs()
+  override def prepareTargetDbs(): Unit = {
+    super.prepareTargetDbs()
     "./src/test/scala/load/physics/copy_domain_data_postgres.sh".!
   }
 

--- a/src/test/scala/load/physics/PhysicsPostgresqlTest.scala
+++ b/src/test/scala/load/physics/PhysicsPostgresqlTest.scala
@@ -27,7 +27,8 @@ class PhysicsPostgresqlTest extends AbstractPostgresqlEndToEndTest with PhysicsT
     "./src/test/scala/load/physics/copy_domain_data_postgres.sh".!
   }
 
-  override val singleThreadedRuntimeThreshold: Long = 400000
-
-  override val akkaStreamsRuntimeThreshold: Long = 2600000
+// TODO: put back when we reintroduce load tests
+//  override val singleThreadedRuntimeThreshold: Long = 400000
+//
+//  override val akkaStreamsRuntimeThreshold: Long = 2600000
 }

--- a/src/test/scala/load/physics/PhysicsPostgresqlTest.scala
+++ b/src/test/scala/load/physics/PhysicsPostgresqlTest.scala
@@ -22,8 +22,8 @@ class PhysicsPostgresqlTest extends AbstractPostgresqlEndToEndTest with PhysicsT
     "--skipPkStore", "public.quantum_data"
   )
 
-  override def prepareTargetDbs(): Unit = {
-    super.prepareTargetDbs()
+  override def prepareTargetDDL(): Unit = {
+    super.prepareTargetDDL()
     "./src/test/scala/load/physics/copy_domain_data_postgres.sh".!
   }
 

--- a/src/test/scala/load/physics/PhysicsPostgresqlTest.scala
+++ b/src/test/scala/load/physics/PhysicsPostgresqlTest.scala
@@ -1,13 +1,13 @@
 package load.physics
 
 import e2e.AbstractPostgresqlEndToEndTest
-import load.LoadTest
 
 import scala.sys.process._
 
-class PhysicsPostgresqlTest extends AbstractPostgresqlEndToEndTest with PhysicsTestCases with LoadTest {
-  override val originPort = 5573
-  override val programArgs = Array(
+class PhysicsPostgresqlTest extends AbstractPostgresqlEndToEndTest with PhysicsTestCases {
+  override protected val originPort = 5573
+
+  override protected val programArgs = Array(
     "--schemas", "public",
     "--baseQuery", "public.scientists ::: id in (2) ::: includeChildren",
     //    TODO: fix so that some experiment plans have no scientist. Then use this base query to test auto-skipPkStore calculations
@@ -22,7 +22,7 @@ class PhysicsPostgresqlTest extends AbstractPostgresqlEndToEndTest with PhysicsT
     "--skipPkStore", "public.quantum_data"
   )
 
-  override def prepareTargetDDL(): Unit = {
+  override protected def prepareTargetDDL(): Unit = {
     super.prepareTargetDDL()
     "./src/test/scala/load/physics/copy_domain_data_postgres.sh".!
   }

--- a/src/test/scala/load/physics/PhysicsTestCases.scala
+++ b/src/test/scala/load/physics/PhysicsTestCases.scala
@@ -7,6 +7,7 @@ import util.assertion.AssertionUtil
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
+// TODO: Add back in with LoadTest
 trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL with AssertionUtil {
 
   import profile.api._

--- a/src/test/scala/load/physics/PhysicsTestCases.scala
+++ b/src/test/scala/load/physics/PhysicsTestCases.scala
@@ -65,7 +65,7 @@ trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL w
     Await.result(gwFut, Duration.Inf)
   }
 
-  val dataSetName = "physics"
+  val testName = "physics"
 
   test("Correct research_institutions were included") {
     assertCount(ResearchInstitutions, 1)

--- a/src/test/scala/load/physics/PhysicsTestCases.scala
+++ b/src/test/scala/load/physics/PhysicsTestCases.scala
@@ -10,6 +10,8 @@ import scala.concurrent.{Await, Future}
 // TODO: Add back in with LoadTest
 trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL with AssertionUtil {
 
+  protected val testName = "physics"
+
   import profile.api._
 
   override val ddl = schema.create
@@ -65,8 +67,6 @@ trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL w
     Await.result(qdFut, Duration.Inf)
     Await.result(gwFut, Duration.Inf)
   }
-
-  val testName = "physics"
 
   test("Correct research_institutions were included") {
     assertCount(ResearchInstitutions, 1)

--- a/src/test/scala/load/physics/PhysicsTestCases.scala
+++ b/src/test/scala/load/physics/PhysicsTestCases.scala
@@ -1,12 +1,13 @@
 package load.physics
 
-import e2e.{AbstractEndToEndTest, SlickSetupDDL}
+import e2e.SlickSetupDDL
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
-trait PhysicsTestCases extends AbstractEndToEndTest with PhysicsDDL with SlickSetupDDL with AssertionUtil {
+trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL with AssertionUtil {
 
   import profile.api._
 

--- a/src/test/scala/load/physics/PhysicsTestCases.scala
+++ b/src/test/scala/load/physics/PhysicsTestCases.scala
@@ -13,22 +13,22 @@ trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL w
 
   override val ddl = schema.create
 
-  override def setupOriginDML(): Unit = {
+  protected def prepareOriginDML(): Unit = {
     val customDml = new PhysicsDML(profile)
 
-    val dmlFut1 = originDb.run(customDml.initialInserts)
+    val dmlFut1 = originSlick.run(customDml.initialInserts)
     Await.result(dmlFut1, Duration.Inf)
-    val fut2 = originDb.run(DBIO.seq(customDml.particleDomainInserts: _*))
+    val fut2 = originSlick.run(DBIO.seq(customDml.particleDomainInserts: _*))
     Await.result(fut2, Duration.Inf)
-    val fut3 = originDb.run(DBIO.seq(customDml.quantumDomainInserts: _*))
+    val fut3 = originSlick.run(DBIO.seq(customDml.quantumDomainInserts: _*))
     Await.result(fut3, Duration.Inf)
-    val fut4 = originDb.run(DBIO.seq(customDml.gravitationalWaveDomainInserts: _*))
+    val fut4 = originSlick.run(DBIO.seq(customDml.gravitationalWaveDomainInserts: _*))
     Await.result(fut4, Duration.Inf)
-    val fut5 = originDb.run(DBIO.seq(customDml.particleColliderDataInserts: _*))
+    val fut5 = originSlick.run(DBIO.seq(customDml.particleColliderDataInserts: _*))
     Await.result(fut5, Duration.Inf)
-    val fut6 = originDb.run(DBIO.seq(customDml.quantumDataInserts: _*))
+    val fut6 = originSlick.run(DBIO.seq(customDml.quantumDataInserts: _*))
     Await.result(fut6, Duration.Inf)
-    val fut7 = originDb.run(DBIO.seq(customDml.gravitationalWaveDataInserts: _*))
+    val fut7 = originSlick.run(DBIO.seq(customDml.gravitationalWaveDataInserts: _*))
     Await.result(fut7, Duration.Inf)
 
     import scala.concurrent.ExecutionContext.Implicits.global
@@ -37,7 +37,7 @@ trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL w
       (1 to customDml.numParticleColliderData by 50).foreach { i =>
         if ((i - 1) % 100000 == 0) println(s"ParticleCollider-$i")
         val inserts = (i to i + 49).map(i => customDml.particleColliderNotesInserts(i))
-        val f = originDb.run(DBIO.seq(inserts: _*))
+        val f = originSlick.run(DBIO.seq(inserts: _*))
         Await.result(f, Duration.Inf)
       }
     }
@@ -46,7 +46,7 @@ trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL w
       (1 to customDml.numQuantumData by 50).foreach { i =>
         if ((i - 1) % 100000 == 0) println(s"Quantum-$i")
         val inserts = (i to i + 49).map(i => customDml.quantumNotesInserts(i))
-        val f = originDb.run(DBIO.seq(inserts: _*))
+        val f = originSlick.run(DBIO.seq(inserts: _*))
         Await.result(f, Duration.Inf)
       }
     }
@@ -55,7 +55,7 @@ trait PhysicsTestCases extends FunSuiteLike with PhysicsDDL with SlickSetupDDL w
       (1 to customDml.numGravitationalWaveData by 50).foreach { i =>
         if ((i - 1) % 100000 == 0) println(s"GravitationalWave-$i")
         val inserts = (i to i + 49).map(i => customDml.gravitationWaveNotesInserts(i))
-        val f = originDb.run(DBIO.seq(inserts: _*))
+        val f = originSlick.run(DBIO.seq(inserts: _*))
         Await.result(f, Duration.Inf)
       }
     }

--- a/src/test/scala/load/schooldb/SchoolDbDDL.scala
+++ b/src/test/scala/load/schooldb/SchoolDbDDL.scala
@@ -1,7 +1,7 @@
 package load.schooldb
 
 trait SchoolDbDDL {
-  val profile: slick.jdbc.JdbcProfile
+  protected val profile: slick.jdbc.JdbcProfile
 
   val mainSchema: String = "school_db"
 

--- a/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
@@ -21,8 +21,8 @@ class SchoolDbMysqlTest extends AbstractMysqlEndToEndTest with SchoolDbTestCases
     super.setupOriginDDL()
   }
 
-  override def setupTargetDbs(): Unit = {
-    super.setupTargetDbs()
+  override def prepareTargetDbs(): Unit = {
+    super.prepareTargetDbs()
     s"./src/test/util/create_mysql_db.sh Audit $targetSithContainerName".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh Audit $originContainerName $targetSithContainerName".!!
     s"./src/test/util/create_mysql_db.sh Audit $targetAkstContainerName".!!

--- a/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
@@ -16,16 +16,16 @@ class SchoolDbMysqlTest extends AbstractMysqlEndToEndTest with SchoolDbTestCases
     "--preTargetBufferSize", "10000"
   )
 
-  override protected def prepareOriginDDL(): Unit = {
-    super.prepareOriginDDL()
+  override protected def createEmptyDatabases(): Unit = {
+    super.createEmptyDatabases()
     s"./src/test/util/create_mysql_db.sh Audit ${containers.origin.name}".!!
+    s"./src/test/util/create_mysql_db.sh Audit ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/create_mysql_db.sh Audit ${containers.targetAkkaStreams.name}".!!
   }
 
   override protected def prepareTargetDDL(): Unit = {
     super.prepareTargetDDL()
-    s"./src/test/util/create_mysql_db.sh Audit ${containers.targetSingleThreaded.name}".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh Audit ${containers.origin.name} ${containers.targetSingleThreaded.name}".!!
-    s"./src/test/util/create_mysql_db.sh Audit ${containers.targetAkkaStreams.name}".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh Audit ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
   }
 

--- a/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
@@ -29,7 +29,8 @@ class SchoolDbMysqlTest extends AbstractMysqlEndToEndTest with SchoolDbTestCases
     s"./src/test/util/sync_mysql_origin_to_target.sh Audit ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
   }
 
-  override val singleThreadedRuntimeThreshold: Long = 1150000
-
-  override val akkaStreamsRuntimeThreshold: Long = 120000
+// TODO: put back when we reintroduce load tests
+//  override val singleThreadedRuntimeThreshold: Long = 1150000
+//
+//  override val akkaStreamsRuntimeThreshold: Long = 120000
 }

--- a/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
@@ -1,11 +1,10 @@
 package load.schooldb
 
 import e2e.AbstractMysqlEndToEndTest
-import load.LoadTest
 
 import scala.sys.process._
 
-class SchoolDbMysqlTest extends AbstractMysqlEndToEndTest with SchoolDbTestCases with LoadTest {
+class SchoolDbMysqlTest extends AbstractMysqlEndToEndTest with SchoolDbTestCases {
   override protected val originPort = 5450
 
   override protected val programArgs = Array(

--- a/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
@@ -21,8 +21,8 @@ class SchoolDbMysqlTest extends AbstractMysqlEndToEndTest with SchoolDbTestCases
     super.setupOriginDDL()
   }
 
-  override def prepareTargetDbs(): Unit = {
-    super.prepareTargetDbs()
+  override def prepareTargetDDL(): Unit = {
+    super.prepareTargetDDL()
     s"./src/test/util/create_mysql_db.sh Audit $targetSithContainerName".!!
     s"./src/test/util/sync_mysql_origin_to_target.sh Audit $originContainerName $targetSithContainerName".!!
     s"./src/test/util/create_mysql_db.sh Audit $targetAkstContainerName".!!

--- a/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbMysqlTest.scala
@@ -6,8 +6,9 @@ import load.LoadTest
 import scala.sys.process._
 
 class SchoolDbMysqlTest extends AbstractMysqlEndToEndTest with SchoolDbTestCases with LoadTest {
-  override val originPort = 5450
-  override val programArgs = Array(
+  override protected val originPort = 5450
+
+  override protected val programArgs = Array(
     "--schemas", "school_db,Audit",
     "--baseQuery", "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",
     "--baseQuery", "school_db.standalone_table ::: id < 4 ::: includeChildren",
@@ -16,17 +17,17 @@ class SchoolDbMysqlTest extends AbstractMysqlEndToEndTest with SchoolDbTestCases
     "--preTargetBufferSize", "10000"
   )
 
-  override def setupOriginDDL(): Unit = {
-    s"./src/test/util/create_mysql_db.sh Audit $originContainerName".!!
-    super.setupOriginDDL()
+  override protected def prepareOriginDDL(): Unit = {
+    super.prepareOriginDDL()
+    s"./src/test/util/create_mysql_db.sh Audit ${containers.origin.name}".!!
   }
 
-  override def prepareTargetDDL(): Unit = {
+  override protected def prepareTargetDDL(): Unit = {
     super.prepareTargetDDL()
-    s"./src/test/util/create_mysql_db.sh Audit $targetSithContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh Audit $originContainerName $targetSithContainerName".!!
-    s"./src/test/util/create_mysql_db.sh Audit $targetAkstContainerName".!!
-    s"./src/test/util/sync_mysql_origin_to_target.sh Audit $originContainerName $targetAkstContainerName".!!
+    s"./src/test/util/create_mysql_db.sh Audit ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh Audit ${containers.origin.name} ${containers.targetSingleThreaded.name}".!!
+    s"./src/test/util/create_mysql_db.sh Audit ${containers.targetAkkaStreams.name}".!!
+    s"./src/test/util/sync_mysql_origin_to_target.sh Audit ${containers.origin.name} ${containers.targetAkkaStreams.name}".!!
   }
 
   override val singleThreadedRuntimeThreshold: Long = 1150000

--- a/src/test/scala/load/schooldb/SchoolDbPostgresqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbPostgresqlTest.scala
@@ -1,14 +1,13 @@
 package load.schooldb
 
 import e2e.AbstractPostgresqlEndToEndTest
-import load.LoadTest
 import slick.dbio.DBIO
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class SchoolDbPostgresqlTest extends AbstractPostgresqlEndToEndTest with SchoolDbTestCases with LoadTest {
+class SchoolDbPostgresqlTest extends AbstractPostgresqlEndToEndTest with SchoolDbTestCases {
   override protected val originPort = 5453
 
   override protected val programArgs = Array(

--- a/src/test/scala/load/schooldb/SchoolDbPostgresqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbPostgresqlTest.scala
@@ -9,8 +9,9 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
 class SchoolDbPostgresqlTest extends AbstractPostgresqlEndToEndTest with SchoolDbTestCases with LoadTest {
-  override val originPort = 5453
-  override val programArgs = Array(
+  override protected val originPort = 5453
+
+  override protected val programArgs = Array(
     "--schemas", "school_db,Audit",
     "--baseQuery", "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",
     "--baseQuery", "school_db.standalone_table ::: id < 4 ::: includeChildren",
@@ -19,13 +20,13 @@ class SchoolDbPostgresqlTest extends AbstractPostgresqlEndToEndTest with SchoolD
     "--preTargetBufferSize", "10000"
   )
 
-  override def setupOriginDDL(): Unit = {
+  override protected def prepareOriginDDL(): Unit = {
     val createSchemaStatements: DBIO[Unit] = DBIO.seq(
       sqlu"create schema school_db",
       sqlu"""create schema "Audit""""
     )
-    Await.ready(originDb.run(createSchemaStatements), Duration.Inf)
-    super.setupOriginDDL()
+    Await.ready(originSlick.run(createSchemaStatements), Duration.Inf)
+    super.prepareOriginDML()
   }
 
   override val singleThreadedRuntimeThreshold: Long = 220000

--- a/src/test/scala/load/schooldb/SchoolDbPostgresqlTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbPostgresqlTest.scala
@@ -28,7 +28,8 @@ class SchoolDbPostgresqlTest extends AbstractPostgresqlEndToEndTest with SchoolD
     super.prepareOriginDML()
   }
 
-  override val singleThreadedRuntimeThreshold: Long = 220000
-
-  override val akkaStreamsRuntimeThreshold: Long = 25000
+// TODO: put back when we reintroduce load tests
+//  override val singleThreadedRuntimeThreshold: Long = 220000
+//
+//  override val akkaStreamsRuntimeThreshold: Long = 25000
 }

--- a/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
@@ -6,8 +6,9 @@ import load.LoadTest
 import scala.sys.process._
 
 class SchoolDbSqlServerTest extends AbstractSqlServerEndToEndTest with SchoolDbTestCases with LoadTest {
-  override val port = 5456
-  override val programArgs = Array(
+  override protected val port = 5456
+
+  override protected val programArgs = Array(
     "--schemas", "school_db,Audit",
     "--baseQuery", "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",
     "--baseQuery", "school_db.standalone_table ::: id < 4 ::: includeChildren",
@@ -16,10 +17,10 @@ class SchoolDbSqlServerTest extends AbstractSqlServerEndToEndTest with SchoolDbT
     "--preTargetBufferSize", "10000"
   )
 
-  override def setupOriginDDL(): Unit = {
-    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName school_db".!!
-    s"./src/test/util/create_schema_sqlserver.sh $containerName $dataSetName Audit".!!
-    super.setupOriginDDL()
+  override protected def prepareOriginDDL(): Unit = {
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} $dataSetName school_db".!!
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} $dataSetName Audit".!!
+    super.prepareOriginDDL()
   }
 
   override val singleThreadedRuntimeThreshold: Long = 110000

--- a/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
@@ -18,8 +18,8 @@ class SchoolDbSqlServerTest extends AbstractSqlServerEndToEndTest with SchoolDbT
   )
 
   override protected def prepareOriginDDL(): Unit = {
-    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} $dataSetName school_db".!!
-    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} $dataSetName Audit".!!
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} $testName school_db".!!
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} $testName Audit".!!
     super.prepareOriginDDL()
   }
 

--- a/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
@@ -1,11 +1,10 @@
 package load.schooldb
 
 import e2e.AbstractSqlServerEndToEndTest
-import load.LoadTest
 
 import scala.sys.process._
 
-class SchoolDbSqlServerTest extends AbstractSqlServerEndToEndTest with SchoolDbTestCases with LoadTest {
+class SchoolDbSqlServerTest extends AbstractSqlServerEndToEndTest with SchoolDbTestCases {
   override protected val port = 5456
 
   override protected val programArgs = Array(

--- a/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
@@ -6,7 +6,7 @@ import load.LoadTest
 import scala.sys.process._
 
 class SchoolDbSqlServerTest extends AbstractSqlServerEndToEndTest with SchoolDbTestCases with LoadTest {
-  override val originPort = 5456
+  override val port = 5456
   override val programArgs = Array(
     "--schemas", "school_db,Audit",
     "--baseQuery", "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",

--- a/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
+++ b/src/test/scala/load/schooldb/SchoolDbSqlServerTest.scala
@@ -22,7 +22,8 @@ class SchoolDbSqlServerTest extends AbstractSqlServerEndToEndTest with SchoolDbT
     super.prepareOriginDDL()
   }
 
-  override val singleThreadedRuntimeThreshold: Long = 110000
-
-  override val akkaStreamsRuntimeThreshold: Long = 25000
+// TODO: put back when we reintroduce load tests
+//  override val singleThreadedRuntimeThreshold: Long = 110000
+//
+//  override val akkaStreamsRuntimeThreshold: Long = 25000
 }

--- a/src/test/scala/load/schooldb/SchoolDbTestCases.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestCases.scala
@@ -10,6 +10,8 @@ import scala.concurrent.duration.Duration
 // TODO add back in LoadTest
 trait SchoolDbTestCases extends FunSuiteLike with SchoolDbDDL with SlickSetupDDL with AssertionUtil {
 
+  protected val testName = "school_db"
+
   import profile.api._
 
   override val ddl = schema.create
@@ -29,8 +31,6 @@ trait SchoolDbTestCases extends FunSuiteLike with SchoolDbDDL with SlickSetupDDL
     val dmlFut6 = originSlick.run(customDml.latestValedictorianCacheUpdates)
     Await.result(dmlFut6, Duration.Inf)
   }
-
-  val testName = "school_db"
 
   test("Correct students were included") {
     assertCount(Students, 35758)

--- a/src/test/scala/load/schooldb/SchoolDbTestCases.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestCases.scala
@@ -13,19 +13,19 @@ trait SchoolDbTestCases extends FunSuiteLike with SchoolDbDDL with SlickSetupDDL
 
   override val ddl = schema.create
 
-  override def setupOriginDML(): Unit = {
+  def prepareOriginDML(): Unit = {
     val customDml = new SchoolDBDML(profile)
-    val dmlFut1 = originDb.run(customDml.initialInserts)
+    val dmlFut1 = originSlick.run(customDml.initialInserts)
     Await.result(dmlFut1, Duration.Inf)
-    val dmlFut2 = originDb.run(customDml.homeworkGradeInserts)
+    val dmlFut2 = originSlick.run(customDml.homeworkGradeInserts)
     Await.result(dmlFut2, Duration.Inf)
-    val dmlFut3 = originDb.run(customDml.eventInserts1)
+    val dmlFut3 = originSlick.run(customDml.eventInserts1)
     Await.result(dmlFut3, Duration.Inf)
-    val dmlFut4 = originDb.run(customDml.eventsInsert2)
+    val dmlFut4 = originSlick.run(customDml.eventsInsert2)
     Await.result(dmlFut4, Duration.Inf)
-    val dmlFut5 = originDb.run(customDml.eventsInsert3)
+    val dmlFut5 = originSlick.run(customDml.eventsInsert3)
     Await.result(dmlFut5, Duration.Inf)
-    val dmlFut6 = originDb.run(customDml.latestValedictorianCacheUpdates)
+    val dmlFut6 = originSlick.run(customDml.latestValedictorianCacheUpdates)
     Await.result(dmlFut6, Duration.Inf)
   }
 

--- a/src/test/scala/load/schooldb/SchoolDbTestCases.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestCases.scala
@@ -29,7 +29,7 @@ trait SchoolDbTestCases extends FunSuiteLike with SchoolDbDDL with SlickSetupDDL
     Await.result(dmlFut6, Duration.Inf)
   }
 
-  val dataSetName = "school_db"
+  val testName = "school_db"
 
   test("Correct students were included") {
     assertCount(Students, 35758)

--- a/src/test/scala/load/schooldb/SchoolDbTestCases.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestCases.scala
@@ -1,12 +1,13 @@
 package load.schooldb
 
-import e2e.{AbstractEndToEndTest, SlickSetupDDL}
+import e2e.SlickSetupDDL
+import org.scalatest.FunSuiteLike
 import util.assertion.AssertionUtil
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-trait SchoolDbTestCases extends AbstractEndToEndTest with SchoolDbDDL with SlickSetupDDL with AssertionUtil {
+trait SchoolDbTestCases extends FunSuiteLike with SchoolDbDDL with SlickSetupDDL with AssertionUtil {
 
   import profile.api._
 

--- a/src/test/scala/load/schooldb/SchoolDbTestCases.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestCases.scala
@@ -7,6 +7,7 @@ import util.assertion.AssertionUtil
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
+// TODO add back in LoadTest
 trait SchoolDbTestCases extends FunSuiteLike with SchoolDbDDL with SlickSetupDDL with AssertionUtil {
 
   import profile.api._

--- a/src/test/scala/util/assertion/AssertionUtil.scala
+++ b/src/test/scala/util/assertion/AssertionUtil.scala
@@ -2,7 +2,6 @@ package util.assertion
 
 import org.scalatest.Assertions
 import slick.dbio.{DBIOAction, Effect}
-import slick.jdbc.JdbcBackend
 import slick.lifted.{AbstractTable, TableQuery}
 
 import scala.concurrent.Await
@@ -11,8 +10,8 @@ import scala.concurrent.duration.Duration
 trait AssertionUtil extends Assertions {
 
   val profile: slick.jdbc.JdbcProfile
-  def targetSingleThreadedSlick: JdbcBackend#DatabaseDef
-  def targetAkkaStreamsSlick: JdbcBackend#DatabaseDef
+  def targetSingleThreadedSlick: profile.backend.DatabaseDef
+  def targetAkkaStreamsSlick: profile.backend.DatabaseDef
 
   final def assertCount[T <: AbstractTable[_]](tq: TableQuery[T], expected: Long): Unit = {
     import profile.api._

--- a/src/test/scala/util/assertion/AssertionUtil.scala
+++ b/src/test/scala/util/assertion/AssertionUtil.scala
@@ -11,28 +11,28 @@ import scala.concurrent.duration.Duration
 trait AssertionUtil extends Assertions {
 
   val profile: slick.jdbc.JdbcProfile
-  def targetDbSt: JdbcBackend#DatabaseDef
-  def targetDbAs: JdbcBackend#DatabaseDef
+  def targetSingleThreadedSlick: JdbcBackend#DatabaseDef
+  def targetAkkaStreamsSlick: JdbcBackend#DatabaseDef
 
   final def assertCount[T <: AbstractTable[_]](tq: TableQuery[T], expected: Long): Unit = {
     import profile.api._
-    assert(Await.result(targetDbSt.run(tq.size.result), Duration.Inf) === expected)
-    assert(Await.result(targetDbAs.run(tq.size.result), Duration.Inf) === expected)
+    assert(Await.result(targetSingleThreadedSlick.run(tq.size.result), Duration.Inf) === expected)
+    assert(Await.result(targetAkkaStreamsSlick.run(tq.size.result), Duration.Inf) === expected)
   }
 
   // Helper to get around intelliJ warnings, technically it could compile just with the Long version
   final def assertThat(action: DBIOAction[Option[Int], profile.api.NoStream, Effect.Read], expected: Long): Unit = {
-    assert(Await.result(targetDbSt.run(action), Duration.Inf) === Some(expected))
-    assert(Await.result(targetDbAs.run(action), Duration.Inf) === Some(expected))
+    assert(Await.result(targetSingleThreadedSlick.run(action), Duration.Inf) === Some(expected))
+    assert(Await.result(targetAkkaStreamsSlick.run(action), Duration.Inf) === Some(expected))
   }
 
   final def assertResult[T](action: DBIOAction[T, profile.api.NoStream, Effect.Read], expected: T): Unit = {
-    assert(Await.result(targetDbSt.run(action), Duration.Inf) === expected)
-    assert(Await.result(targetDbAs.run(action), Duration.Inf) === expected)
+    assert(Await.result(targetSingleThreadedSlick.run(action), Duration.Inf) === expected)
+    assert(Await.result(targetAkkaStreamsSlick.run(action), Duration.Inf) === expected)
   }
 
   final def assertThatLong(action: DBIOAction[Option[Long], profile.api.NoStream, Effect.Read], expected: Long): Unit = {
-    assert(Await.result(targetDbSt.run(action), Duration.Inf) === Some(expected))
-    assert(Await.result(targetDbAs.run(action), Duration.Inf) === Some(expected))
+    assert(Await.result(targetSingleThreadedSlick.run(action), Duration.Inf) === Some(expected))
+    assert(Await.result(targetAkkaStreamsSlick.run(action), Duration.Inf) === Some(expected))
   }
 }

--- a/src/test/scala/util/assertion/AssertionUtil.scala
+++ b/src/test/scala/util/assertion/AssertionUtil.scala
@@ -9,9 +9,11 @@ import scala.concurrent.duration.Duration
 
 trait AssertionUtil extends Assertions {
 
-  val profile: slick.jdbc.JdbcProfile
-  def targetSingleThreadedSlick: profile.backend.DatabaseDef
-  def targetAkkaStreamsSlick: profile.backend.DatabaseDef
+  protected val profile: slick.jdbc.JdbcProfile
+
+  protected def targetSingleThreadedSlick: profile.backend.DatabaseDef
+
+  protected def targetAkkaStreamsSlick: profile.backend.DatabaseDef
 
   final def assertCount[T <: AbstractTable[_]](tq: TableQuery[T], expected: Long): Unit = {
     import profile.api._

--- a/src/test/scala/util/db/Database.scala
+++ b/src/test/scala/util/db/Database.scala
@@ -1,0 +1,3 @@
+package util.db
+
+class Database(name: String, port: Int, username: String, password: String)

--- a/src/test/scala/util/db/Database.scala
+++ b/src/test/scala/util/db/Database.scala
@@ -1,3 +1,6 @@
 package util.db
 
-class Database(name: String, port: Int, username: String, password: String)
+trait Database {
+  def name: String
+  def connectionString: String
+}

--- a/src/test/scala/util/db/Database.scala
+++ b/src/test/scala/util/db/Database.scala
@@ -2,5 +2,18 @@ package util.db
 
 trait Database {
   def name: String
+  def port: Int
   def connectionString: String
+}
+
+class MySqlDatabase(val name: String, val port: Int) extends Database {
+  override def connectionString: String = s"jdbc:mysql://localhost:$port/$name?user=root&useSSL=false&rewriteBatchedStatements=true"
+}
+
+class PostgreSQLDatabase(val name: String, val port: Int) extends Database {
+  override def connectionString: String = s"jdbc:postgresql://0.0.0.0:$port/$name?user=postgres"
+}
+
+class SqlServerDatabase(val name: String, val port: Int) extends Database {
+  override def connectionString: String = s"jdbc:sqlserver://localhost:$port;databaseName=$name;user=sa;password=MsSqlServerLocal1"
 }

--- a/src/test/scala/util/db/DatabaseContainer.scala
+++ b/src/test/scala/util/db/DatabaseContainer.scala
@@ -31,3 +31,4 @@ object DatabaseContainer {
 
 class MySqlContainer(val name: String, val db: MySqlDatabase) extends DatabaseContainer[MySqlDatabase]
 class PostgreSQLContainer(val name: String, val db: PostgreSQLDatabase) extends DatabaseContainer[PostgreSQLDatabase]
+class SqlServerContainer(val name: String, val db: SqlServerDatabase) extends DatabaseContainer[SqlServerDatabase]

--- a/src/test/scala/util/db/DatabaseContainer.scala
+++ b/src/test/scala/util/db/DatabaseContainer.scala
@@ -1,0 +1,5 @@
+package util.db
+
+import util.docker.Container
+
+trait DatabaseContainer extends Container[Database]

--- a/src/test/scala/util/db/DatabaseContainer.scala
+++ b/src/test/scala/util/db/DatabaseContainer.scala
@@ -2,4 +2,7 @@ package util.db
 
 import util.docker.Container
 
-trait DatabaseContainer extends Container[Database]
+class DatabaseContainer(container: Container[Database]) {
+  def name: String = container.name
+  def db: Database = container.process
+}

--- a/src/test/scala/util/db/DatabaseContainer.scala
+++ b/src/test/scala/util/db/DatabaseContainer.scala
@@ -2,7 +2,20 @@ package util.db
 
 import util.docker.Container
 
-class DatabaseContainer(container: Container[Database]) {
+import scala.sys.process._
+
+class DatabaseContainer[T <: Database](container: Container[T]) {
   def name: String = container.name
-  def db: Database = container.process
+  def db: T = container.process
+}
+
+object DatabaseContainer {
+  def createMySqlContainer(name: String, port: Int): Unit = {
+    s"docker create --name $name -p $port:3306 --env MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.0.3".!!
+  }
+
+  def createPostgreSQLContainer(name: String, port: Int): Unit = {
+    s"docker create --name $name -p $port:5432 postgres:9.6.3".!!
+  }
+
 }

--- a/src/test/scala/util/db/DatabaseContainer.scala
+++ b/src/test/scala/util/db/DatabaseContainer.scala
@@ -1,6 +1,6 @@
 package util.db
 
-import util.docker.Container
+import util.docker.{Container, ContainerUtil}
 
 import scala.sys.process._
 
@@ -10,12 +10,21 @@ class DatabaseContainer[T <: Database](container: Container[T]) {
 }
 
 object DatabaseContainer {
-  def createMySqlContainer(name: String, port: Int): Unit = {
+  def startMySql(name: String, port: Int): Unit = {
+    ContainerUtil.rm(name)
     s"docker create --name $name -p $port:3306 --env MYSQL_ALLOW_EMPTY_PASSWORD=true mysql:8.0.3".!!
+    ContainerUtil.start(name)
   }
 
-  def createPostgreSQLContainer(name: String, port: Int): Unit = {
+  def startPostgreSQL(name: String, port: Int): Unit = {
+    ContainerUtil.rm(name)
     s"docker create --name $name -p $port:5432 postgres:9.6.3".!!
+    ContainerUtil.start(name)
   }
 
+  def startSqlServer(name: String, port: Int): Unit = {
+    ContainerUtil.rm(name)
+    s"docker create --name $name -p $port:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU12 /opt/mssql/bin/sqlservr".!!
+    ContainerUtil.start(name)
+  }
 }

--- a/src/test/scala/util/db/DatabaseContainer.scala
+++ b/src/test/scala/util/db/DatabaseContainer.scala
@@ -30,3 +30,4 @@ object DatabaseContainer {
 }
 
 class MySqlContainer(val name: String, val db: MySqlDatabase) extends DatabaseContainer[MySqlDatabase]
+class PostgreSQLContainer(val name: String, val db: PostgreSQLDatabase) extends DatabaseContainer[PostgreSQLDatabase]

--- a/src/test/scala/util/db/DatabaseContainer.scala
+++ b/src/test/scala/util/db/DatabaseContainer.scala
@@ -1,12 +1,12 @@
 package util.db
 
-import util.docker.{Container, ContainerUtil}
+import util.docker.ContainerUtil
 
 import scala.sys.process._
 
-class DatabaseContainer[T <: Database](container: Container[T]) {
-  def name: String = container.name
-  def db: T = container.process
+trait DatabaseContainer[T <: Database] {
+  def name: String
+  def db: T
 }
 
 object DatabaseContainer {
@@ -28,3 +28,5 @@ object DatabaseContainer {
     ContainerUtil.start(name)
   }
 }
+
+class MySqlContainer(val name: String, val db: MySqlDatabase) extends DatabaseContainer[MySqlDatabase]

--- a/src/test/scala/util/db/DatabaseContainerSet.scala
+++ b/src/test/scala/util/db/DatabaseContainerSet.scala
@@ -1,0 +1,3 @@
+package util.db
+
+class DatabaseContainerSet(val origin: DatabaseContainer, val targetSingleThreaded: DatabaseContainer, val targetAkkaStreams: DatabaseContainer)

--- a/src/test/scala/util/db/DatabaseContainerSet.scala
+++ b/src/test/scala/util/db/DatabaseContainerSet.scala
@@ -1,3 +1,7 @@
 package util.db
 
-class DatabaseContainerSet(val origin: DatabaseContainer, val targetSingleThreaded: DatabaseContainer, val targetAkkaStreams: DatabaseContainer)
+class DatabaseContainerSet[T <: Database](
+  val origin: DatabaseContainer[T],
+  val targetSingleThreaded: DatabaseContainer[T],
+  val targetAkkaStreams: DatabaseContainer[T]
+)

--- a/src/test/scala/util/docker/Container.scala
+++ b/src/test/scala/util/docker/Container.scala
@@ -1,0 +1,10 @@
+package util.docker
+
+import java.net.URI
+
+
+trait Container[T] {
+  def name: String
+  def uri: URI
+  def process: T
+}

--- a/src/test/scala/util/docker/Container.scala
+++ b/src/test/scala/util/docker/Container.scala
@@ -1,10 +1,7 @@
 package util.docker
 
-import java.net.URI
-
 
 trait Container[T] {
   def name: String
-  def uri: URI
   def process: T
 }

--- a/src/test/scala/util/docker/Container.scala
+++ b/src/test/scala/util/docker/Container.scala
@@ -1,6 +1,5 @@
 package util.docker
 
-
 trait Container[T] {
   def name: String
   def process: T

--- a/src/test/scala/util/docker/ContainerUtil.scala
+++ b/src/test/scala/util/docker/ContainerUtil.scala
@@ -3,11 +3,11 @@ package util.docker
 import scala.sys.process._
 
 object ContainerUtil {
-  def rm(containerName: String): Unit = {
-    s"docker rm --force --volumes $containerName".!
+  def rm(name: String): Unit = {
+    s"docker rm --force --volumes $name".!
   }
 
-  def start(containerName: String): Unit = {
-    s"docker start $containerName".!
+  def start(name: String): Unit = {
+    s"docker start $name".!
   }
 }


### PR DESCRIPTION
Part 3 of a refactoring effort to make our testing infrastructure simpler and easier to work with in the future. Continue extracting things from AbstractEndToEndTest, to try to reduce its large footprint.

This time, extract many DB-connection related fields out of AbstractEndToEndTest, replacing them with a single field that holds a `var containers: DatabaseContainerSet`. The `containers` variable holds all of the same info, just centralized in one better-structured class hierarchy, rather than having the info live in many fields right on the AbstractEndToEndTest class. Examples of fields that have now been removed from AbstractEndToEndTest include:

```scala
  lazy val originDbName: String = dataSetName
  lazy val targetSingleThreadedDbName: String = originDbName
  lazy val targetAkkaStreamsDbName: String = originDbName
  lazy val targetSingleThreadedPort: Int = originPort + 1
  lazy val targetAkkaStreamsPort: Int = originPort + 2
  lazy val targetSingleThreadedConnString: String = makeConnStr(targetSingleThreadedPort, targetSingleThreadedDbName)
  lazy val targetAkkaStreamsConnString: String = makeConnStr(targetAkkaStreamsPort, targetAkkaStreamsDbName)
```