### PR TITLE
Refactor test infra mysql optimization less containers for e2e tests

### DIFF
--- a/src/test/scala/e2e/SharedTestContainers.scala
+++ b/src/test/scala/e2e/SharedTestContainers.scala
@@ -6,9 +6,9 @@ import util.docker.ContainerUtil
 object SharedTestContainers {
   private val dbName = "do-not-use"
 
-  lazy val postgres: DatabaseContainer[PostgreSQLDatabase] = {
+  lazy val postgres: PostgreSQLContainer = {
     val containerName = "e2e_postgres"
-    val port = 5497
+    val port = 5495
     DatabaseContainer.startPostgreSQL(containerName, port)
     val db = new PostgreSQLDatabase(dbName, port)
 
@@ -22,9 +22,9 @@ object SharedTestContainers {
 
   lazy val awaitPostgresUp: Unit = Thread.sleep(4000)
 
-  lazy val sqlServer: DatabaseContainer[SqlServerDatabase] = {
+  lazy val sqlServer: SqlServerContainer = {
     val containerName = "e2e_sql_server"
-    val port = 5499
+    val port = 5496
     DatabaseContainer.startSqlServer(containerName, port)
     val db = new SqlServerDatabase(dbName, port)
 
@@ -37,4 +37,22 @@ object SharedTestContainers {
   }
 
   lazy val awaitSqlServerUp: Unit = Thread.sleep(5000)
+
+  lazy val mysqlOrigin: DatabaseContainer[MySqlDatabase] = startMysql("e2e_mysql_origin", 5497)
+  lazy val mysqlTargetSingleThreaded: DatabaseContainer[MySqlDatabase] = startMysql("e2e_mysql_target_single_threaded", 5498)
+  lazy val mysqlTargetAkkaStreams: DatabaseContainer[MySqlDatabase] = startMysql("e2e_mysql_target_akka_streams", 5499)
+
+  lazy val awaitMysqlUp: Unit = Thread.sleep(13000)
+
+  private def startMysql(containerName: String, port: Int): MySqlContainer = {
+    DatabaseContainer.startMySql(containerName, port)
+    val db = new MySqlDatabase(dbName, port)
+
+    /*
+     * Remove container on JVM shutdown
+     */
+    sys.addShutdownHook(ContainerUtil.rm(containerName))
+
+    new MySqlContainer(containerName, db)
+  }
 }

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestMySql.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestMySql.scala
@@ -3,7 +3,6 @@ package e2e.autoincrementingpk
 import e2e.AbstractMysqlEndToEndTest
 
 class AutoIncrementingPkTestMySql extends AbstractMysqlEndToEndTest with AutoIncrementingPkTest {
-  override protected val originPort = 5550
 
   override protected val programArgs = Array(
     "--schemas", "autoincrementing_pk",

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestMySql.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestMySql.scala
@@ -3,7 +3,6 @@ package e2e.basequeries
 import e2e.AbstractMysqlEndToEndTest
 
 class BaseQueriesTestMySql extends AbstractMysqlEndToEndTest with BaseQueriesTest {
-  override protected val originPort = 5510
 
   override protected val programArgs = Array(
     "--schemas", "base_queries",

--- a/src/test/scala/e2e/circulardep/CircularDepTestMySql.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestMySql.scala
@@ -3,7 +3,7 @@ package e2e.circulardep
 import e2e.AbstractMysqlEndToEndTest
 
 class CircularDepTestMySql extends AbstractMysqlEndToEndTest with CircularDepTest {
-  override val originPort = 5480
+
   override val programArgs = Array(
     "--schemas", "circular_dep",
     "--baseQuery", "circular_dep.grandparents ::: id % 6 = 0 ::: includeChildren",

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestMySql.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestMySql.scala
@@ -6,8 +6,6 @@ import scala.sys.process._
 
 class CrossSchemaTestMySql extends AbstractMysqlEndToEndTest with CrossSchemaTest {
 
-  override protected val originPort = 5540
-
   override protected val programArgs = Array(
     "--schemas", "schema_1, schema_2,schema_3",
     "--baseQuery", "schema_1.schema_1_table ::: id = 2 ::: includeChildren"

--- a/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestMySql.scala
+++ b/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestMySql.scala
@@ -3,7 +3,7 @@ package e2e.fktononpk
 import e2e.AbstractMysqlEndToEndTest
 
 class ForeignKeyToNonPrimaryKeyTestMySql extends AbstractMysqlEndToEndTest with ForeignKeyToNonPrimaryKeyTest {
-  override val originPort = 5560
+
   override val programArgs = Array(
     "--schemas", "fk_reference_non_pk",
     "--baseQuery", "fk_reference_non_pk.referenced_table ::: id in (1, 4) ::: includeChildren",

--- a/src/test/scala/e2e/missingfk/MissingFkTestMySql.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestMySql.scala
@@ -3,7 +3,7 @@ package e2e.missingfk
 import e2e.AbstractMysqlEndToEndTest
 
 class MissingFkTestMySql extends AbstractMysqlEndToEndTest with MissingFkTest {
-  override val originPort = 5490
+
   override val programArgs = Array(
     "--schemas", "missing_fk",
     "--baseQuery", "missing_fk.table_1 ::: id = 2 ::: includeChildren",

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestMySql.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestMySql.scala
@@ -3,7 +3,7 @@ package e2e.mixedcase
 import e2e.AbstractMysqlEndToEndTest
 
 class MixedCaseTestMySql extends AbstractMysqlEndToEndTest with MixedCaseTest {
-  override val originPort = 5530
+
   override val programArgs = Array(
     "--schemas", "mIXED_case_DB",
     "--baseQuery", "mIXED_case_DB.mixed_CASE_table_1 ::: `ID` = 2 ::: includeChildren",

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesTest.scala
@@ -10,8 +10,6 @@ import scala.sys.process._
 class MySqlDataTypesTest extends AbstractMysqlEndToEndTest with AssertionUtil {
   override protected val testName = "mysql_data_types"
 
-  override protected val originPort = 5580
-
   override protected val programArgs = Array(
     "--schemas", "mysql_data_types",
     "--baseQuery", "mysql_data_types.tinyints_signed ::: id in (127) ::: includeChildren",

--- a/src/test/scala/e2e/pktypes/PkTypesTestMySql.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestMySql.scala
@@ -3,7 +3,6 @@ package e2e.pktypes
 import e2e.AbstractMysqlEndToEndTest
 
 class PkTypesTestMySql extends AbstractMysqlEndToEndTest with PkTypesTest {
-  override val originPort = 5570
 
   override def expectedChar10Ids = Seq[String](" four", "two")
 

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestMySql.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestMySql.scala
@@ -3,7 +3,7 @@ package e2e.selfreferencing
 import e2e.AbstractMysqlEndToEndTest
 
 class SelfReferencingTestMySql extends AbstractMysqlEndToEndTest with SelfReferencingTest {
-  override val originPort = 5520
+
   override val programArgs = Array(
     "--schemas", "self_referencing",
     "--baseQuery", "self_referencing.self_referencing_table ::: id in (1, 3, 13, 14, 15) ::: includeChildren"

--- a/src/test/scala/load/schooldb/SchoolDbTestMySql.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestMySql.scala
@@ -12,8 +12,6 @@ class SchoolDbTestMySql extends AbstractMysqlEndToEndTest with LoadTest[MySqlDat
 
   override val akkaStreamsRuntimeLimitMillis: Long = 120000
 
-  override protected val originPort = 5450
-
   override protected val programArgs = Array(
     "--schemas", "school_db,Audit",
     "--baseQuery", "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",

--- a/src/test/scala/util/runner/TestSubsetRunner.scala
+++ b/src/test/scala/util/runner/TestSubsetRunner.scala
@@ -27,14 +27,14 @@ object TestSubsetRunner {
     val singleThreadedRuntimeMillis = (System.nanoTime() - startSingleThreaded) / 1000000
     println(s"Single Threaded Took $singleThreadedRuntimeMillis milliseconds")
 
-    return singleThreadedRuntimeMillis
+    singleThreadedRuntimeMillis
   }
 
   def runSubsetInAkkaStreamsMode[T <: Database](containers: DatabaseContainerSet[T], programArgs: Array[String]): Long = {
     val defaultArgs: Array[String] = Array(
       "--originDbConnStr", containers.origin.db.connectionString,
-      "--originDbParallelism", "10",
-      "--targetDbParallelism", "10",
+      "--originDbParallelism", "2",
+      "--targetDbParallelism", "2",
       "--targetDbConnStr", containers.targetAkkaStreams.db.connectionString
     )
     val finalArgs: Array[String] = defaultArgs ++ programArgs
@@ -49,6 +49,6 @@ object TestSubsetRunner {
     val akkStreamsRuntimeMillis = (System.nanoTime() - startAkkaStreams) / 1000000
     println(s"Akka Streams Took $akkStreamsRuntimeMillis milliseconds")
 
-    return akkStreamsRuntimeMillis
+    akkStreamsRuntimeMillis
   }
 }


### PR DESCRIPTION
Continue with optimization started here: https://github.com/bluerogue251/DBSubsetter/pull/53, this time focusing on using less MySQL containers to improve test runtime.