### PR TITLE
Start adding Observability Infrastructure (Prometheus/Grafana)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,7 @@ libraryDependencies ++= Seq(
   // Akka stream processing
   "com.typesafe.akka" %% "akka-stream" % "2.5.8",
 
-  // JDBC Drivers
+  // JDBC drivers
   "org.postgresql" % "postgresql" % "42.1.4",
   "mysql" % "mysql-connector-java" % "8.0.8-dmr",
   "com.microsoft.sqlserver" % "mssql-jdbc" % "6.2.1.jre8",
@@ -22,9 +22,12 @@ libraryDependencies ++= Seq(
   // No-op logger to silence slf4j warnings
   "org.slf4j" % "slf4j-nop" % "1.7.25",
 
+  // Observability tools
+  "io.prometheus" % "simpleclient" % "0.6.0",
+  "io.prometheus" % "simpleclient_httpserver" % "0.6.0",
+
   // For testing only
   "org.scalatest" %% "scalatest" % "3.0.4" % "test",
   "com.typesafe.slick" %% "slick" % "3.2.1" % "test",
-  "com.typesafe.slick" %% "slick-hikaricp" % "3.2.1" % "test",
-  "org.slf4j" % "slf4j-nop" % "1.6.4" % "test"
+  "com.typesafe.slick" %% "slick-hikaricp" % "3.2.1" % "test"
 )

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -1,0 +1,141 @@
+{
+  "dashboard": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "gnetId": null,
+    "graphTooltip": 0,
+    "id": null,
+    "links": [],
+    "panels": [
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 6,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "id": 2,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": true,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "rate(OriginDbWorkflow_count[1s])",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Rate Per Second",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Origin DB Selects",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      }
+    ],
+    "refresh": "5s",
+    "schemaVersion": 1,
+    "style": "dark",
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-15m",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m"
+      ],
+      "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h"
+      ]
+    },
+    "timezone": "",
+    "title": "DBSubsetter Metrics",
+    "uid": null,
+    "version": 0
+  }
+}

--- a/observability-tools.sh
+++ b/observability-tools.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -ou pipefail
+
+docker rm --force --volumes db_subsetter_grafana
+docker rm --force --volumes db_subsetter_prometheus
+#docker rm --force --volumes db_subsetter_prometheus_pushgateway
+
+docker run \
+  --detach \
+  --publish 3000:3000 \
+  --name db_subsetter_grafana \
+  grafana/grafana:5.4.2
+
+docker run \
+  --detach \
+  --network host \
+  --name db_subsetter_prometheus \
+  --volume $(pwd)/prometheus-config.yml:/etc/prometheus/prometheus.yml \
+  prom/prometheus:v2.6.0

--- a/observability-tools.sh
+++ b/observability-tools.sh
@@ -2,14 +2,10 @@
 
 set -ou pipefail
 
-docker rm --force --volumes db_subsetter_grafana
 docker rm --force --volumes db_subsetter_prometheus
+docker rm --force --volumes db_subsetter_grafana
 
-docker run \
-  --detach \
-  --network host \
-  --name db_subsetter_grafana \
-  grafana/grafana:5.4.2
+set -e
 
 docker run \
   --detach \
@@ -17,6 +13,12 @@ docker run \
   --name db_subsetter_prometheus \
   --volume $(pwd)/prometheus-config.yml:/etc/prometheus/prometheus.yml \
   prom/prometheus:v2.6.0
+
+docker run \
+  --detach \
+  --network host \
+  --name db_subsetter_grafana \
+  grafana/grafana:5.4.2
 
 sleep 5
 

--- a/observability-tools.sh
+++ b/observability-tools.sh
@@ -35,3 +35,14 @@ curl \
   admin:admin@localhost:3000/api/dashboards/db
 
 echo ""
+
+curl \
+  -X PUT \
+  -H 'Content-Type: application/json' \
+  --data '{ "homeDashboardId": 1 }' \
+  admin:admin@localhost:3000/api/user/preferences
+
+echo ""
+echo ""
+
+echo "You can now view your DBSubsetter metrics at http://localhost:3000 (user: admin, password: admin)"

--- a/prometheus-config.yml
+++ b/prometheus-config.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval:     500ms
+  evaluation_interval: 500ms
+
+scrape_configs:
+  - job_name: 'db_subsetter'
+    static_configs:
+      - targets: ['localhost:9092']

--- a/src/main/scala/trw/dbsubsetter/Application.scala
+++ b/src/main/scala/trw/dbsubsetter/Application.scala
@@ -1,34 +1,35 @@
 package trw.dbsubsetter
 
+import io.prometheus.client.exporter.HTTPServer
 import trw.dbsubsetter.config.{CommandLineParser, Config}
 import trw.dbsubsetter.db.SchemaInfoRetrieval
 import trw.dbsubsetter.util.Util
 import trw.dbsubsetter.workflow.BaseQueries
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.util.{Failure, Success}
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
 
 object Application extends App {
   val startingTime = System.nanoTime()
 
   CommandLineParser.parser.parse(args, Config()) match {
-    case None => System.exit(1)
+    case None =>
+      System.exit(1)
     case Some(config) =>
       val schemaInfo = SchemaInfoRetrieval.getSchemaInfo(config)
       val baseQueries = BaseQueries.get(config, schemaInfo)
 
+      val prometheusExportPort = 9092
+      val prometheusServerRunsInBackground = true
+      val httpServer: HTTPServer = new HTTPServer(prometheusExportPort, prometheusServerRunsInBackground)
+
       if (config.isSingleThreadedDebugMode) {
         ApplicationSingleThreaded.run(config, schemaInfo, baseQueries)
-        Util.printRuntime(startingTime)
       } else {
         val futureResult = ApplicationAkkaStreams.run(config, schemaInfo, baseQueries)
-        futureResult.onComplete {
-          case Success(_) =>
-            Util.printRuntime(startingTime)
-          case Failure(e) =>
-            e.printStackTrace()
-            System.exit(1)
-        }
+        Await.ready(futureResult, Duration.Inf)
       }
+      Util.printRuntime(startingTime)
+      httpServer.stop()
   }
 }


### PR DESCRIPTION
First step towards achieving https://github.com/bluerogue251/DBSubsetter/issues/50

* Add shell script to easily create Prometheus Docker Container and Grafana Docker Container (pre-configured with prometheus as a data source,  and with a pre-defined default dashboard with graphs displaying DBSubsetter metrics)
* Configure DBSubsetter to expose a Prometheus scrape endpoint
* Add one `Histogram` to the `OriginDbWorkflow` as a proof of concept of integrating Prometheus into DBSubsetter