### PR TITLE
Make connection factory a singleton

### DIFF
--- a/src/main/scala/trw/dbsubsetter/db/DbAccessFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/DbAccessFactory.scala
@@ -8,8 +8,6 @@ import trw.dbsubsetter.db.impl.target.{TargetDbAccessImpl, TargetDbAccessTimed}
 
 class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
 
-  private[this] val connectionFactory = new ConnectionFactory()
-
   def buildOriginDbAccess(): OriginDbAccess = {
     var mapper: JdbcResultConverter =
       new JdbcResultConverterImpl(schemaInfo)
@@ -19,7 +17,7 @@ class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
     }
 
     var originDbAccess: OriginDbAccess =
-      new OriginDbAccessImpl(config.originDbConnectionString, schemaInfo, connectionFactory, mapper)
+      new OriginDbAccessImpl(config.originDbConnectionString, schemaInfo, mapper)
 
     if (config.exposeMetrics) {
       originDbAccess = new OriginDbAccessTimed(originDbAccess)
@@ -30,7 +28,7 @@ class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
 
   def buildTargetDbAccess(): TargetDbAccess = {
     var targetDbAccess: TargetDbAccess =
-      new TargetDbAccessImpl(config.targetDbConnectionString, schemaInfo, connectionFactory)
+      new TargetDbAccessImpl(config.targetDbConnectionString, schemaInfo)
 
     if (config.exposeMetrics) {
        targetDbAccess = new TargetDbAccessTimed(targetDbAccess)
@@ -40,6 +38,6 @@ class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
   }
 
   def closeAllConnections(): Unit = {
-    connectionFactory.closeAllConnections()
+    ConnectionFactory.closeAllConnections()
   }
 }

--- a/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 /*
  * CAREFUL: NOT THREADSAFE
  */
-private[db] object ConnectionFactory {
+private[impl] object ConnectionFactory {
 
   /*
    * Records all open connections so that we can remember to call `close()` on them when we are finished

--- a/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
@@ -7,12 +7,12 @@ import scala.collection.mutable
 /*
  * CAREFUL: NOT THREADSAFE
  */
-private[db] class ConnectionFactory {
+private[db] object ConnectionFactory {
 
   /*
    * Records all open connections so that we can remember to call `close()` on them when we are finished
    */
-  private[this] val registry: mutable.Set[Connection] = mutable.Set.empty[Connection]
+  private val registry: mutable.Set[Connection] = mutable.Set.empty[Connection]
 
   def closeAllConnections(): Unit = {
     registry.foreach(_.close())
@@ -31,7 +31,7 @@ private[db] class ConnectionFactory {
     conn
   }
 
-  private[this] def createAndRegisterConnection(connectionString: String): Connection = {
+  private def createAndRegisterConnection(connectionString: String): Connection = {
     val conn: Connection = DriverManager.getConnection(connectionString)
     import trw.dbsubsetter.db._
     if (conn.isMysql) conn.createStatement().execute("SET SESSION SQL_MODE = ANSI_QUOTES")

--- a/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
@@ -12,7 +12,7 @@ private[db] object ConnectionFactory {
   /*
    * Records all open connections so that we can remember to call `close()` on them when we are finished
    */
-  private val registry: mutable.Set[Connection] = mutable.Set.empty[Connection]
+  private[this] val registry: mutable.Set[Connection] = mutable.Set.empty[Connection]
 
   def closeAllConnections(): Unit = {
     registry.foreach(_.close())
@@ -31,7 +31,7 @@ private[db] object ConnectionFactory {
     conn
   }
 
-  private def createAndRegisterConnection(connectionString: String): Connection = {
+  private[this] def createAndRegisterConnection(connectionString: String): Connection = {
     val conn: Connection = DriverManager.getConnection(connectionString)
     import trw.dbsubsetter.db._
     if (conn.isMysql) conn.createStatement().execute("SET SESSION SQL_MODE = ANSI_QUOTES")

--- a/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 /*
  * CAREFUL: NOT THREADSAFE
  */
-private[impl] object ConnectionFactory {
+private[db] object ConnectionFactory {
 
   /*
    * Records all open connections so that we can remember to call `close()` on them when we are finished

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -4,9 +4,9 @@ import trw.dbsubsetter.db.impl.connection.ConnectionFactory
 import trw.dbsubsetter.db.impl.mapper.JdbcResultConverter
 import trw.dbsubsetter.db.{ForeignKey, OriginDbAccess, Row, SchemaInfo, Sql, SqlQuery, Table}
 
-private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, connectionFactory: ConnectionFactory, mapper: JdbcResultConverter) extends OriginDbAccess {
+private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: JdbcResultConverter) extends OriginDbAccess {
 
-  private val conn = connectionFactory.getReadOnlyConnection(connStr)
+  private val conn = ConnectionFactory.getReadOnlyConnection(connStr)
 
   private val statements = Sql.preparedQueryStatementStrings(sch).map { case ((fk, table), sqlStr) =>
     (fk, table) -> conn.prepareStatement(sqlStr)


### PR DESCRIPTION
This helps ensure we remember to close all connections by making sure there is only one factory out there for us to call closeAllConnections() on.