### PR TITLE
Extract separate classes for FetchParentTask and FetchChildrenTask

### DIFF
--- a/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
+++ b/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
@@ -19,9 +19,17 @@ object ApplicationSingleThreaded {
 
     // Run task queue until empty
     while (taskTracker.nonEmpty) {
-      val taskOpt: List[OriginDbRequest] = taskTracker.dequeueTask() match {
-        case t: FkTask if FkTaskPreCheck.shouldPrecheck(t) => List(pkWorkflow.exists(t)).collect { case t: FkTask => t }
-        case t => List(t)
+      val task: OriginDbRequest = taskTracker.dequeueTask()
+      val mightBeAbleToSkipTask: Boolean = TaskPreCheck.shouldPrecheck(task)
+      val optionalTask: Option[OriginDbRequest] = {
+        if (mightBeAbleToSkipTask)
+          pkWorkflow.exists(task).
+        Some(task)
+        else
+      }
+
+
+        case t => Some(t)
       }
       taskOpt.foreach { task =>
         val dbResult = originDbWorkflow.process(task)

--- a/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
+++ b/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
@@ -2,6 +2,7 @@ package trw.dbsubsetter
 
 import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
+import trw.dbsubsetter.primarykeystore.{PrimaryKeyStore, PrimaryKeyStoreFactory}
 import trw.dbsubsetter.singlethreaded.{TaskTracker, TaskTrackerFactory}
 import trw.dbsubsetter.workflow._
 
@@ -11,7 +12,8 @@ object ApplicationSingleThreaded {
     val dbAccessFactory = new DbAccessFactory(config, schemaInfo)
     val originDbWorkflow = new OriginDbWorkflow(config, schemaInfo, dbAccessFactory)
     val targetDbWorkflow = new TargetDbWorkflow(config, schemaInfo, dbAccessFactory)
-    val pkWorkflow = new PkStoreWorkflow(schemaInfo)
+    val pkStore: PrimaryKeyStore = PrimaryKeyStoreFactory.getPrimaryKeyStore(schemaInfo)
+    val pkWorkflow: PkStoreWorkflow = new PkStoreWorkflow(pkStore)
 
     // Set up task queue
     val taskTracker: TaskTracker = TaskTrackerFactory.buildTaskTracker(config)

--- a/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
@@ -22,7 +22,7 @@ object Subsetting {
     val balanceOriginDb = b.add(Balance[OriginDbRequest](config.originDbParallelism, waitForAllDownstreams = true))
     val mergeOriginDbResults = b.add(Merge[OriginDbResult](config.originDbParallelism))
     val partitionOriginDbResults = b.add(Partition[OriginDbResult](2, res => if (res.table.storePks) 1 else 0))
-    val partitionFkTasks = b.add(Partition[FkTask](2, t => if (FkTaskPreCheck.shouldPrecheck(t)) 1 else 0))
+    val partitionFkTasks = b.add(Partition[FkTask](2, t => if (TaskPreCheck.shouldPrecheck(t)) 1 else 0))
     val broadcastPkExistResult = b.add(Broadcast[PkResult](2))
     val mergePksAdded = b.add(Merge[PksAdded](2))
     val broadcastPksAdded = b.add(Broadcast[PksAdded](2))

--- a/src/main/scala/trw/dbsubsetter/primarykeystore/PrimaryKeyStore.scala
+++ b/src/main/scala/trw/dbsubsetter/primarykeystore/PrimaryKeyStore.scala
@@ -1,0 +1,10 @@
+package trw.dbsubsetter.primarykeystore
+
+import trw.dbsubsetter.db.Table
+
+trait PrimaryKeyStore {
+  def markSeen(table: Table, primaryKeyValue: Any): Boolean
+  def markSeenWithChildren(table: Table, primaryKeyValue: Any): Boolean
+  def alreadySeen(table: Table, primaryKeyValue: Any): Boolean
+  def alreadySeenWithChildren(table: Table, primaryKeyValue: Any): Boolean
+}

--- a/src/main/scala/trw/dbsubsetter/primarykeystore/PrimaryKeyStoreFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/primarykeystore/PrimaryKeyStoreFactory.scala
@@ -1,0 +1,16 @@
+package trw.dbsubsetter.primarykeystore
+
+import trw.dbsubsetter.db.SchemaInfo
+import trw.dbsubsetter.primarykeystore.impl.InMemoryPrimaryKeyStore
+
+object PrimaryKeyStoreFactory {
+
+  private[this] var lazyInitializedPrimaryKeyStoreSingleton: PrimaryKeyStore = _
+
+  def getPrimaryKeyStore(schemaInfo: SchemaInfo): PrimaryKeyStore = {
+    if (lazyInitializedPrimaryKeyStoreSingleton == null) {
+      lazyInitializedPrimaryKeyStoreSingleton = new InMemoryPrimaryKeyStore(schemaInfo)
+    }
+    lazyInitializedPrimaryKeyStoreSingleton
+  }
+}

--- a/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
+++ b/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
@@ -1,0 +1,53 @@
+package trw.dbsubsetter.primarykeystore.impl
+
+import trw.dbsubsetter.db.{SchemaInfo, Table}
+import trw.dbsubsetter.primarykeystore.PrimaryKeyStore
+
+import scala.collection.mutable
+
+/*
+ * CAREFUL -- NOT THREADSAFE
+ */
+class InMemoryPrimaryKeyStore(schemaInfo: SchemaInfo) extends PrimaryKeyStore {
+
+  private[this] val tables = schemaInfo.pksByTableOrdered.keys.filter(_.storePks)
+
+  // If `seenWithChildrenStorage` contains a PK, then both its children AND its parents have been fetched.
+  // If `seenWithoutChildrenStorage` contains a PK, then only its parents have been fetched.
+
+  // There is no such thing as having fetched a row's children but not having fetched its parents.
+
+  // If a PK is in there at all, then at any given time, it is either in `seenWithoutChildrenStorage` or
+  // in `seenWithChildrenStorage` -- it will never be in both at once.
+  private[this] val seenWithoutChildrenStorage: Map[Table, mutable.HashSet[Any]] = tables.map { t =>
+    t -> mutable.HashSet.empty[Any]
+  }.toMap
+
+  private[this] val seenWithChildrenStorage: Map[Table, mutable.HashSet[Any]] = tables.map { t =>
+    t -> mutable.HashSet.empty[Any]
+  }.toMap
+
+  override def markSeen(table: Table, primaryKeyValue: Any): Boolean = {
+    val alreadySeenWithChildren: Boolean =
+      seenWithChildrenStorage(table).contains(primaryKeyValue)
+
+    if (alreadySeenWithChildren)
+      false
+    else
+      seenWithoutChildrenStorage(table).add(primaryKeyValue)
+  }
+
+  override def markSeenWithChildren(table: Table, primaryKeyValue: Any): Boolean = {
+    seenWithoutChildrenStorage(table).remove(primaryKeyValue)
+    !seenWithChildrenStorage(table).add(primaryKeyValue)
+  }
+
+  override def alreadySeen(table: Table, primaryKeyValue: Any): Boolean = {
+    seenWithChildrenStorage(table).contains(primaryKeyValue) ||
+      seenWithoutChildrenStorage(table).contains(primaryKeyValue)
+  }
+
+  override def alreadySeenWithChildren(table: Table, primaryKeyValue: Any): Boolean = {
+    seenWithChildrenStorage(table).contains(primaryKeyValue)
+  }
+}

--- a/src/main/scala/trw/dbsubsetter/workflow/FkTaskPreCheck.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/FkTaskPreCheck.scala
@@ -1,7 +1,0 @@
-package trw.dbsubsetter.workflow
-
-object FkTaskPreCheck {
-  def shouldPrecheck(task: FkTask): Boolean = {
-    task.fk.pointsToPk && task.table.storePks && task.table == task.fk.toTable
-  }
-}

--- a/src/main/scala/trw/dbsubsetter/workflow/PkStoreWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/PkStoreWorkflow.scala
@@ -1,36 +1,21 @@
 package trw.dbsubsetter.workflow
 
-import trw.dbsubsetter.db.{Row, SchemaInfo, Table}
+import trw.dbsubsetter.db.Row
+import trw.dbsubsetter.primarykeystore.PrimaryKeyStore
 
-import scala.collection.mutable
 
+class PkStoreWorkflow(pkStore: PrimaryKeyStore) {
 
-class PkStoreWorkflow(sch: SchemaInfo) {
-  private val tables = sch.pksByTableOrdered.keys.filter(_.storePks)
-  // Left side of the tuple is for parents, right side of the tuple is for children
-  // If a PK is on the children side, then both its children AND its parents have been fetched.
-  // IF a PK is on the parent side, then only its parents have been fetched
-  // There is no such thing as having fetched a row's children but not having fetched its parents
-  // If a PK is in there at all, then at any given time, it is either in the parent set or child set, never both at once.
-  //
-  // Optimization may be possible by changing AnyRef to Any, and/or changing HashSet to TreeSet
-  // Using `Any` would in theory allow us to use primitive Ints instead of Integer for PK storage, etc.
-  // TreeSet in theory might provide more stable runtime of operations, so that we never encounter one big
-  // time when we need to double the size of the HashSet, etc.
-  // Both potential optimizations would need testing: it's not clear how much if any good they would do
-  private val pkStore: Map[Table, (mutable.HashSet[Any], mutable.HashSet[Any])] = tables.map { t =>
-    t -> (mutable.HashSet.empty[Any], mutable.HashSet.empty[Any])
-  }.toMap
-
-  def exists(req: FkTask): PkResult = {
-    val FkTask(table, _, fkValue, fetchChildren) = req
-    val (parentStore, childStore) = getStorage(table)
-
-    if (fetchChildren) {
-      if (childStore.contains(fkValue)) DuplicateTask else req
-    } else {
-      if (parentStore.contains(fkValue) || childStore.contains(fkValue)) DuplicateTask else req
+  def exists(task: ForeignKeyTask): PkResult = {
+    val alreadyProcessed: Boolean = task match {
+      case FetchParentTask(foreignKey, value) => pkStore.alreadySeen(foreignKey.toTable, value)
+      case FetchChildrenTask(foreignKey, value) => pkStore.alreadySeenWithChildren(foreignKey.fromTable, value)
     }
+
+    if (alreadyProcessed)
+      DuplicateTask
+    else
+      task
   }
 
   def add(req: OriginDbResult): PksAdded = {
@@ -53,9 +38,5 @@ class PkStoreWorkflow(sch: SchemaInfo) {
       }
       PksAdded(table, newRows, Vector.empty, viaTableOpt)
     }
-  }
-
-  def getStorage(t: Table): (mutable.HashSet[Any], mutable.HashSet[Any]) = {
-    pkStore.getOrElse(t, throw new RuntimeException(s"No primary key defined for table $t"))
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/TaskPreCheck.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/TaskPreCheck.scala
@@ -1,10 +1,7 @@
 package trw.dbsubsetter.workflow
 
 object TaskPreCheck {
-  def shouldPrecheck(originDbRequest: OriginDbRequest): Boolean = {
-    originDbRequest match {
-      case FetchParentTask(foreignKey, _) => foreignKey.pointsToPk && foreignKey.toTable.storePks
-      case _ => false
-    }
+  def shouldPrecheck(fetchParentTask: FetchParentTask): Boolean = {
+    fetchParentTask.foreignKey.pointsToPk && fetchParentTask.foreignKey.toTable.storePks
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/TaskPreCheck.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/TaskPreCheck.scala
@@ -1,0 +1,10 @@
+package trw.dbsubsetter.workflow
+
+object TaskPreCheck {
+  def shouldPrecheck(originDbRequest: OriginDbRequest): Boolean = {
+    originDbRequest match {
+      case FetchParentTask(foreignKey, _) => foreignKey.pointsToPk && foreignKey.toTable.storePks
+      case _ => false
+    }
+  }
+}

--- a/src/main/scala/trw/dbsubsetter/workflow/package.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/package.scala
@@ -4,11 +4,15 @@ import trw.dbsubsetter.db._
 
 package object workflow {
 
-  case class FkTask(table: Table, fk: ForeignKey, fkValue: Any, fetchChildren: Boolean) extends OriginDbRequest with PkResult
-
   sealed trait OriginDbRequest
 
+  sealed trait ForeignKeyTask extends PkResult
+
   case class BaseQuery(table: Table, sql: SqlQuery, fetchChildren: Boolean) extends OriginDbRequest
+
+  case class FetchParentTask(foreignKey: ForeignKey, value: Any) extends OriginDbRequest with ForeignKeyTask
+
+  case class FetchChildrenTask(foreignKey: ForeignKey, value: Any) extends OriginDbRequest with ForeignKeyTask
 
   case class OriginDbResult(table: Table, rows: Vector[Row], viaTableOpt: Option[Table], fetchChildren: Boolean)
 


### PR DESCRIPTION
This refactor is intended to aid in eventually implementing the akka-streams half of this: https://github.com/bluerogue251/DBSubsetter/pull/61

It started with trying to make sense of [this type signature](https://github.com/bluerogue251/DBSubsetter/blob/0c919095a12d8bcc0ba45cc55fa03dc42e172d54/src/main/scala/trw/dbsubsetter/akkastreams/OutstandingTaskCounter.scala#L9) which led to the desire to refactor for more clarity around what, exactly those types are, specifically the `Flow[Map[(ForeignKey, Boolean), Array[Any]]`. Ideally, that would instead be something 

It also got started with the idea that the "counting of outstanding tasks" could somehow be built straight into the queuing mechanism [here](https://github.com/bluerogue251/DBSubsetter/blob/0c919095a12d8bcc0ba45cc55fa03dc42e172d54/src/main/scala/trw/dbsubsetter/akkastreams/FkTaskBufferFlow.scala). Again, the type signature was difficult to understand and it seemed like simplifying the types would be a good first step to being able to alter that code. (A good second step would be to extract two classes from that one -- one class to represent an Akka-Streams `Flow`, which delegates to another class which is responsible for writing to and reading from Chronicle Queue).