### PR TITLE
Composition over inheritance for Pk Results

### DIFF
--- a/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
+++ b/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
@@ -32,7 +32,7 @@ object ApplicationSingleThreaded {
         val pksAdded = if (dbResult.table.storePks) pkWorkflow.add(dbResult) else SkipPkStore.process(dbResult)
         targetDbWorkflow.process(pksAdded)
         val newTasks = NewFkTaskWorkflow.process(pksAdded, schemaInfo)
-        newTasks.foreach { case ((fk, fetchChildren), fkValues) =>
+        newTasks.taskInfo.foreach { case ((fk, fetchChildren), fkValues) =>
           val tasks = fkValues.map { v =>
             val table = if (fetchChildren) fk.fromTable else fk.toTable
             FkTask(table, fk, v, fetchChildren)

--- a/src/main/scala/trw/dbsubsetter/akkastreams/NewTasks.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/NewTasks.scala
@@ -6,17 +6,7 @@ import trw.dbsubsetter.db.{ForeignKey, SchemaInfo}
 import trw.dbsubsetter.workflow._
 
 object NewTasks {
-  def flow(sch: SchemaInfo): Flow[PkResult, Map[(ForeignKey, Boolean), Array[Any]], NotUsed] = {
-    Flow[PkResult].map[Map[(ForeignKey, Boolean), Array[Any]]] { pkResult => {
-      pkResult match {
-        case pka: PksAdded =>
-          NewFkTaskWorkflow.process(pka, sch)
-        case DuplicateTask => // TODO should go to the counter instead of coming here first
-          Map.empty
-        case other =>
-          throw new RuntimeException(s"Cannot handle $other") // TODO: Make this a compile time error
-      }
-    }
-    }
+  def flow(sch: SchemaInfo): Flow[PksAdded, NewTasks, NotUsed] = {
+    Flow[PksAdded].map[Map[(ForeignKey, Boolean), Array[Any]]](pksAdded => NewFkTaskWorkflow.process(pksAdded, sch))
   }
 }

--- a/src/main/scala/trw/dbsubsetter/akkastreams/NewTasks.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/NewTasks.scala
@@ -2,11 +2,11 @@ package trw.dbsubsetter.akkastreams
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
-import trw.dbsubsetter.db.{ForeignKey, SchemaInfo}
+import trw.dbsubsetter.db.SchemaInfo
 import trw.dbsubsetter.workflow._
 
 object NewTasks {
   def flow(sch: SchemaInfo): Flow[PksAdded, NewTasks, NotUsed] = {
-    Flow[PksAdded].map[Map[(ForeignKey, Boolean), Array[Any]]](pksAdded => NewFkTaskWorkflow.process(pksAdded, sch))
+    Flow[PksAdded].map(pksAdded => NewFkTaskWorkflow.process(pksAdded, sch))
   }
 }

--- a/src/main/scala/trw/dbsubsetter/akkastreams/OutstandingTaskCounter.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/OutstandingTaskCounter.scala
@@ -4,7 +4,6 @@ import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import trw.dbsubsetter.workflow.NewTasks
 
-// TODO try to make the Array[Any] type more specific
 object OutstandingTaskCounter {
   def counter(numBaseQueries: Int): Flow[NewTasks, NewTasks, NotUsed] = {
     val counterFlow = Flow[NewTasks].statefulMapConcat { () =>

--- a/src/main/scala/trw/dbsubsetter/akkastreams/OutstandingTaskCounter.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/OutstandingTaskCounter.scala
@@ -2,27 +2,26 @@ package trw.dbsubsetter.akkastreams
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
-import trw.dbsubsetter.db.ForeignKey
+import trw.dbsubsetter.workflow.NewTasks
 
 // TODO try to make the Array[Any] type more specific
 object OutstandingTaskCounter {
-  def counter(numBaseQueries: Int): Flow[Map[(ForeignKey, Boolean), Array[Any]], Map[(ForeignKey, Boolean), Array[Any]], NotUsed] = {
-    val counterFlow = Flow[Map[(ForeignKey, Boolean), Array[Any]]].statefulMapConcat { () =>
+  def counter(numBaseQueries: Int): Flow[NewTasks, NewTasks, NotUsed] = {
+    val counterFlow = Flow[NewTasks].statefulMapConcat { () =>
       var statefulCounter: Long = numBaseQueries
 
-      incoming => {
+      newTasks => {
         statefulCounter -= 1
-        incoming.foreach { case ((_, _), fkValues) =>
+        newTasks.taskInfo.foreach { case ((_, _), fkValues) =>
           statefulCounter += fkValues.length
         }
-
-        List((statefulCounter, incoming))
+        List((statefulCounter, newTasks))
       }
     }
 
-    val circuitBreaker = Flow[(Long, Map[(ForeignKey, Boolean), Array[Any]])].takeWhile { case (counter, _) => counter != 0 }
+    val circuitBreaker = Flow[(Long, NewTasks)].takeWhile { case (counter, _) => counter != 0 }
 
-    val simplifier = Flow[(Long, Map[(ForeignKey, Boolean), Array[Any]])].map { case (_, newTasks) => newTasks }
+    val simplifier = Flow[(Long, NewTasks)].map { case (_, newTasks) => newTasks }
 
     counterFlow.via(circuitBreaker).via(simplifier)
   }

--- a/src/main/scala/trw/dbsubsetter/akkastreams/PkStoreActor.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/PkStoreActor.scala
@@ -16,7 +16,7 @@ private[this] class PkStoreActor(schemaInfo: SchemaInfo) extends Actor {
     // If it's a FkTask, then we are being asked to pre-check to make sure we haven't done it already
     case task: FkTask =>
       val alreadySeen: Boolean = pkStore.alreadySeen(task.table, task.fkValue)
-      val response: PkResult = if (alreadySeen) DuplicateTask else task
+      val response: PkQueryResult = if (alreadySeen) AlreadySeen else NotAlreadySeen(task)
       sender() ! response
     // If it's an OriginDbResult, then we are being asked to add the new primary key values to the PkStore
     case req: OriginDbResult =>

--- a/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
@@ -9,7 +9,7 @@ import akka.stream.{OverflowStrategy, SourceShape}
 import akka.util.Timeout
 import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
-import trw.dbsubsetter.workflow._
+import trw.dbsubsetter.workflow.{AlreadySeen, _}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
@@ -23,13 +23,13 @@ object Subsetting {
     val mergeOriginDbResults = b.add(Merge[OriginDbResult](config.originDbParallelism))
     val partitionOriginDbResults = b.add(Partition[OriginDbResult](2, res => if (res.table.storePks) 1 else 0))
     val partitionFkTasks = b.add(Partition[FkTask](2, t => if (FkTaskPreCheck.shouldPrecheck(t)) 1 else 0))
-    val broadcastPkExistResult = b.add(Broadcast[PkResult](2))
+    val broadcastPkExistResult = b.add(Broadcast[PkQueryResult](2))
     val mergePksAdded = b.add(Merge[PksAdded](2))
     val broadcastPksAdded = b.add(Broadcast[PksAdded](2))
-    val mergeNewTaskRequests = b.add(Merge[PkResult](2))
     val balanceTargetDb = b.add(Balance[PksAdded](config.targetDbParallelism, waitForAllDownstreams = true))
     val mergeTargetDbResults = b.add(Merge[TargetDbInsertResult](config.targetDbParallelism))
     val fkTaskBufferFlow = b.add(new FkTaskBufferFlow(config, schemaInfo).async)
+    val mergeToOustandingTaskCounter = b.add(Merge[NewTasks](2))
 
     // Start everything off
     Source(baseQueries) ~>
@@ -63,8 +63,10 @@ object Subsetting {
       broadcastPksAdded
 
     broadcastPksAdded ~>
-      mergeNewTaskRequests ~>
       NewTasks.flow(schemaInfo) ~>
+      mergeToOustandingTaskCounter
+
+    mergeToOustandingTaskCounter ~>
       OutstandingTaskCounter.counter(baseQueries.size) ~>
       fkTaskBufferFlow
 
@@ -82,16 +84,17 @@ object Subsetting {
       mergeOriginDbRequests
 
     partitionFkTasks.out(1) ~>
-      Flow[FkTask].mapAsyncUnordered(10)(req => (pkStore ? req).mapTo[PkResult]) ~>
+      Flow[FkTask].mapAsyncUnordered(10)(req => (pkStore ? req).mapTo[PkQueryResult]) ~>
       broadcastPkExistResult
 
     broadcastPkExistResult ~>
-      Flow[PkResult].collect { case f: FkTask => f } ~>
+      Flow[PkQueryResult].collect { case NotAlreadySeen(fkTask) => fkTask } ~>
       mergeOriginDbRequests
 
     broadcastPkExistResult ~>
-      Flow[PkResult].collect { case DuplicateTask => DuplicateTask } ~>
-      mergeNewTaskRequests
+      Flow[PkQueryResult].collect { case AlreadySeen => AlreadySeen } ~>
+      Flow[PkQueryResult].map(_ => EmptyNewTasks) ~>     // TODO make type more specific
+      mergeToOustandingTaskCounter
 
     SourceShape(mergeTargetDbResults.out)
   })

--- a/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
@@ -23,6 +23,7 @@ object Subsetting {
     val mergeOriginDbResults = b.add(Merge[OriginDbResult](config.originDbParallelism))
     val partitionOriginDbResults = b.add(Partition[OriginDbResult](2, res => if (res.table.storePks) 1 else 0))
     val partitionFkTasks = b.add(Partition[FkTask](2, t => if (FkTaskPreCheck.shouldPrecheck(t)) 1 else 0))
+    // TODO try to turn this broadcast into a typesafe Partition stage with two output ports, each output port with a different type
     val broadcastPkExistResult = b.add(Broadcast[PkQueryResult](2))
     val mergePksAdded = b.add(Merge[PksAdded](2))
     val broadcastPksAdded = b.add(Broadcast[PksAdded](2))

--- a/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
@@ -92,8 +92,7 @@ object Subsetting {
       mergeOriginDbRequests
 
     broadcastPkExistResult ~>
-      Flow[PkQueryResult].collect { case AlreadySeen => AlreadySeen } ~>
-      Flow[PkQueryResult].map(_ => EmptyNewTasks) ~>     // TODO make type more specific
+      Flow[PkQueryResult].collect { case AlreadySeen => EmptyNewTasks } ~>
       mergeToOustandingTaskCounter
 
     SourceShape(mergeTargetDbResults.out)

--- a/src/main/scala/trw/dbsubsetter/workflow/NewFkTaskWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/NewFkTaskWorkflow.scala
@@ -3,14 +3,14 @@ package trw.dbsubsetter.workflow
 import trw.dbsubsetter.db._
 
 object NewFkTaskWorkflow {
-  def process(pksAdded: PksAdded, sch: SchemaInfo): Map[(ForeignKey, Boolean), Array[Any]] = {
+  def process(pksAdded: PksAdded, sch: SchemaInfo): NewTasks = {
     val PksAdded(table, rowsNeedingParentTasks, rowsNeedingChildTasks, viaTableOpt) = pksAdded
     val parentTasks = calcParentTasks(sch, table, rowsNeedingParentTasks, viaTableOpt)
     val childTasks = calcChildTasks(sch, table, rowsNeedingChildTasks)
-    parentTasks ++ childTasks
+    NewTasks(parentTasks.taskInfo ++ childTasks.taskInfo)
   }
 
-  private def calcParentTasks(sch: SchemaInfo, table: Table, rows: Vector[Row], viaTableOpt: Option[Table]): Map[(ForeignKey, Boolean), Array[Any]] = {
+  private def calcParentTasks(sch: SchemaInfo, table: Table, rows: Vector[Row], viaTableOpt: Option[Table]): NewTasks = {
     // Re: `distinct`
     // It is (hopefully) a performance improvement which prevents duplicate tasks from being created
     //
@@ -24,17 +24,19 @@ object NewFkTaskWorkflow {
     // `filterNot(_ == null)` should also only be necessary for parent tasks, not child tasks
     val allFks = sch.fksFromTable(table)
     val useFks = viaTableOpt.fold(allFks)(viaTable => allFks.filterNot(fk => fk.toTable == viaTable))
-    useFks.map { fk =>
+    val newTasksInfo: Map[(ForeignKey, Boolean), Array[Any]] = useFks.map { fk =>
       val distinctFkValues = valuesFunc(fk)(fk, fk.fromCols, rows).distinct.filterNot(_ == null)
       (fk, false) -> distinctFkValues
     }.toMap
+    NewTasks(newTasksInfo)
   }
 
-  private def calcChildTasks(sch: SchemaInfo, table: Table, rows: Vector[Row]): Map[(ForeignKey, Boolean), Array[Any]] = {
-    sch.fksToTable(table).map { fk =>
+  private def calcChildTasks(sch: SchemaInfo, table: Table, rows: Vector[Row]): NewTasks = {
+    val newTasksInfo: Map[(ForeignKey, Boolean), Array[Any]] = sch.fksToTable(table).map { fk =>
       val fkValues = valuesFunc(fk)(fk, fk.toCols, rows)
       (fk, true) -> fkValues
     }.toMap
+    NewTasks(newTasksInfo)
   }
 
   private def valuesFunc(fk: ForeignKey) = if (fk.isSingleCol) getSingleColForeignKeyValues _ else getMultiColForeignKeyValues _

--- a/src/main/scala/trw/dbsubsetter/workflow/package.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/package.scala
@@ -4,19 +4,20 @@ import trw.dbsubsetter.db._
 
 package object workflow {
 
-  case class FkTask(table: Table, fk: ForeignKey, fkValue: Any, fetchChildren: Boolean) extends OriginDbRequest with PkResult
-
   sealed trait OriginDbRequest
-
+  case class FkTask(table: Table, fk: ForeignKey, fkValue: Any, fetchChildren: Boolean) extends OriginDbRequest
   case class BaseQuery(table: Table, sql: SqlQuery, fetchChildren: Boolean) extends OriginDbRequest
 
   case class OriginDbResult(table: Table, rows: Vector[Row], viaTableOpt: Option[Table], fetchChildren: Boolean)
 
   case class TargetDbInsertResult(table: Table, numRowsInserted: Long)
 
-  sealed trait PkResult
+  case class PksAdded(table: Table, rowsNeedingParentTasks: Vector[Row], rowsNeedingChildTasks: Vector[Row], viaTableOpt: Option[Table])
 
-  case class PksAdded(table: Table, rowsNeedingParentTasks: Vector[Row], rowsNeedingChildTasks: Vector[Row], viaTableOpt: Option[Table]) extends PkResult
+  sealed trait PkQueryResult
+  case object AlreadySeen extends PkQueryResult
+  case class NotAlreadySeen(task: FkTask) extends PkQueryResult
 
-  case object DuplicateTask extends PkResult
+  case class NewTasks(taskInfo: Map[(ForeignKey, Boolean), Array[Any]])
+  val EmptyNewTasks = NewTasks(Map.empty)
 }


### PR DESCRIPTION
* Change `FkTask`, `DuplicateTask`, and `PksAdded` to no longer extend `PkResult`. This gets rid of an awkward inheritance structure where lots of unrelated things extended `PkResult`. Instead, replace `PkResult` with a `PkExistsQueryResult` trait with two options `AlreadySeen` (replaces `DuplicateTask`) or `NotAlreadySeen(task: FkTask)` (which _composes_ a `FkTask` rather than having `FkTask` inherit from it).

* Define a `NewTasks` type to hide some of the messy details of new tasks being represented as `Map[(ForeignKey, Boolean), Array[Any]]`
* Improve AkkaStreams structure so that duplicate tasks are now sent straight to the `OutstandingTaskCounter` instead of first passing through the `NewTasks.flow`.