### PR TITLE
Fix connection registry bugs

### DIFF
--- a/src/main/scala/trw/dbsubsetter/db/DbAccessFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/DbAccessFactory.scala
@@ -8,6 +8,8 @@ import trw.dbsubsetter.db.impl.target.{TargetDbAccessImpl, TargetDbAccessTimed}
 
 class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
 
+  private[this] val connectionFactory: ConnectionFactory = new ConnectionFactory
+
   def buildOriginDbAccess(): OriginDbAccess = {
     var mapper: JdbcResultConverter =
       new JdbcResultConverterImpl(schemaInfo)
@@ -17,7 +19,7 @@ class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
     }
 
     var originDbAccess: OriginDbAccess =
-      new OriginDbAccessImpl(config.originDbConnectionString, schemaInfo, mapper)
+      new OriginDbAccessImpl(config.originDbConnectionString, schemaInfo, mapper, connectionFactory)
 
     if (config.exposeMetrics) {
       originDbAccess = new OriginDbAccessTimed(originDbAccess)
@@ -28,7 +30,7 @@ class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
 
   def buildTargetDbAccess(): TargetDbAccess = {
     var targetDbAccess: TargetDbAccess =
-      new TargetDbAccessImpl(config.targetDbConnectionString, schemaInfo)
+      new TargetDbAccessImpl(config.targetDbConnectionString, schemaInfo, connectionFactory)
 
     if (config.exposeMetrics) {
        targetDbAccess = new TargetDbAccessTimed(targetDbAccess)
@@ -38,6 +40,6 @@ class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
   }
 
   def closeAllConnections(): Unit = {
-    ConnectionFactory.closeAllConnections()
+    connectionFactory.closeAllConnections()
   }
 }

--- a/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
@@ -19,22 +19,23 @@ private[db] class ConnectionFactory {
   }
 
   def getReadOnlyConnection(connectionString: String): Connection = {
-    val conn: Connection = createAndRegisterConnection(connectionString)
-    conn.setReadOnly(true)
-    conn
+    val connection: Connection = createAndRegisterConnection(connectionString)
+    connection.setReadOnly(true)
+    connection
   }
 
   def getConnectionWithWritePrivileges(connectionString: String): Connection = {
-    val conn: Connection = createAndRegisterConnection(connectionString)
+    val connection: Connection = createAndRegisterConnection(connectionString)
     import trw.dbsubsetter.db._
-    if (conn.isMysql) conn.createStatement().execute("SET SESSION FOREIGN_KEY_CHECKS = 0")
-    conn
+    if (connection.isMysql) connection.createStatement().execute("SET SESSION FOREIGN_KEY_CHECKS = 0")
+    connection
   }
 
   private[this] def createAndRegisterConnection(connectionString: String): Connection = {
-    val conn: Connection = DriverManager.getConnection(connectionString)
+    val connection: Connection = DriverManager.getConnection(connectionString)
     import trw.dbsubsetter.db._
-    if (conn.isMysql) conn.createStatement().execute("SET SESSION SQL_MODE = ANSI_QUOTES")
-    conn
+    if (connection.isMysql) connection.createStatement().execute("SET SESSION SQL_MODE = ANSI_QUOTES")
+    registry.add(connection)
+    connection
   }
 }

--- a/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/connection/ConnectionFactory.scala
@@ -7,7 +7,7 @@ import scala.collection.mutable
 /*
  * CAREFUL: NOT THREADSAFE
  */
-private[db] object ConnectionFactory {
+private[db] class ConnectionFactory {
 
   /*
    * Records all open connections so that we can remember to call `close()` on them when we are finished

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -4,11 +4,11 @@ import trw.dbsubsetter.db.impl.connection.ConnectionFactory
 import trw.dbsubsetter.db.impl.mapper.JdbcResultConverter
 import trw.dbsubsetter.db.{ForeignKey, OriginDbAccess, Row, SchemaInfo, Sql, SqlQuery, Table}
 
-private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: JdbcResultConverter) extends OriginDbAccess {
+private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: JdbcResultConverter, connectionFactory: ConnectionFactory) extends OriginDbAccess {
 
-  private val conn = ConnectionFactory.getReadOnlyConnection(connStr)
+  private[this] val conn = connectionFactory.getReadOnlyConnection(connStr)
 
-  private val statements = Sql.preparedQueryStatementStrings(sch).map { case ((fk, table), sqlStr) =>
+  private[this] val statements = Sql.preparedQueryStatementStrings(sch).map { case ((fk, table), sqlStr) =>
     (fk, table) -> conn.prepareStatement(sqlStr)
   }
 

--- a/src/test/scala/util/runner/TestSubsetRunner.scala
+++ b/src/test/scala/util/runner/TestSubsetRunner.scala
@@ -21,8 +21,8 @@ object TestSubsetRunner {
   def runSubsetInAkkaStreamsMode[T <: Database](containers: DatabaseContainerSet[T], programArgs: Array[String]): Long = {
     val defaultArgs: Array[String] = Array(
       "--originDbConnStr", containers.origin.db.connectionString,
-      "--originDbParallelism", "10",
-      "--targetDbParallelism", "10",
+      "--originDbParallelism", "30",
+      "--targetDbParallelism", "30",
       "--targetDbConnStr", containers.targetAkkaStreams.db.connectionString,
       "--exposeMetrics"
     )

--- a/src/test/scala/util/runner/TestSubsetRunner.scala
+++ b/src/test/scala/util/runner/TestSubsetRunner.scala
@@ -21,8 +21,8 @@ object TestSubsetRunner {
   def runSubsetInAkkaStreamsMode[T <: Database](containers: DatabaseContainerSet[T], programArgs: Array[String]): Long = {
     val defaultArgs: Array[String] = Array(
       "--originDbConnStr", containers.origin.db.connectionString,
-      "--originDbParallelism", "30",
-      "--targetDbParallelism", "30",
+      "--originDbParallelism", "10",
+      "--targetDbParallelism", "10",
       "--targetDbConnStr", containers.targetAkkaStreams.db.connectionString,
       "--exposeMetrics"
     )


### PR DESCRIPTION
Fix two bugs with the connection registry:

1) Since `ConnectionFactory` was a singleton, connection factories were being shared across subsetting runs when running multiple e2e tests. Making `ConnectionFactory` a singleton originally seemed like a good idea to make production code safer, but it led to this unwanted sharing when running tests. This PR reverts `ConnectionFactory` back to a `class` from an `object`. Now, each subsetting run has exactly one `ConnectionFactory` rather than each JVM process having exactly one `ConnectionFactory`.

2) In `ConnectionFactory`, we were forgetting to call `registry.add(connection)`, so we also forgot to ever close the connections. This PR fixes that.