### PR TITLE
Restrict access modifiers and add final to some classes and objects

### DIFF
--- a/src/main/scala/trw/dbsubsetter/akkastreams/FkTaskCreation.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/FkTaskCreation.scala
@@ -4,7 +4,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import trw.dbsubsetter.workflow._
 
-object FkTaskCreation {
+private[akkastreams] object FkTaskCreation {
   def flow(fkTaskCreationWorkflow: FkTaskCreationWorkflow): Flow[PksAdded, NewTasks, NotUsed] = {
     Flow[PksAdded].map(fkTaskCreationWorkflow.createFkTasks)
   }

--- a/src/main/scala/trw/dbsubsetter/akkastreams/OriginDb.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/OriginDb.scala
@@ -6,7 +6,7 @@ import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
 import trw.dbsubsetter.workflow._
 
-object OriginDb {
+private[akkastreams] object OriginDb {
   def query(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory): Flow[OriginDbRequest, OriginDbResult, NotUsed] = {
     Flow[OriginDbRequest].statefulMapConcat { () =>
       val dbWorkflow = new OriginDbWorkflow(config, schemaInfo, dbAccessFactory)

--- a/src/main/scala/trw/dbsubsetter/akkastreams/OutstandingTaskCounter.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/OutstandingTaskCounter.scala
@@ -4,7 +4,7 @@ import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import trw.dbsubsetter.workflow.NewTasks
 
-object OutstandingTaskCounter {
+private[akkastreams] object OutstandingTaskCounter {
   def counter(numBaseQueries: Int): Flow[NewTasks, NewTasks, NotUsed] = {
     val counterFlow = Flow[NewTasks].statefulMapConcat { () =>
       var statefulCounter: Long = numBaseQueries

--- a/src/main/scala/trw/dbsubsetter/akkastreams/TargetDb.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/TargetDb.scala
@@ -6,7 +6,7 @@ import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
 import trw.dbsubsetter.workflow._
 
-object TargetDb {
+private[akkastreams] object TargetDb {
   def insert(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory): Flow[PksAdded, TargetDbInsertResult, NotUsed] = {
     Flow[PksAdded].statefulMapConcat { () =>
       val dbWorkflow = new TargetDbWorkflow(config, schemaInfo, dbAccessFactory)

--- a/src/main/scala/trw/dbsubsetter/db/DbAccessFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/db/DbAccessFactory.scala
@@ -6,7 +6,7 @@ import trw.dbsubsetter.db.impl.mapper.{JdbcResultConverter, JdbcResultConverterI
 import trw.dbsubsetter.db.impl.origin.{OriginDbAccessImpl, OriginDbAccessTimed}
 import trw.dbsubsetter.db.impl.target.{TargetDbAccessImpl, TargetDbAccessTimed}
 
-class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
+final class DbAccessFactory(config: Config, schemaInfo: SchemaInfo) {
 
   private[this] val connectionFactory: ConnectionFactory = new ConnectionFactory
 

--- a/src/main/scala/trw/dbsubsetter/db/DbMetadataQueries.scala
+++ b/src/main/scala/trw/dbsubsetter/db/DbMetadataQueries.scala
@@ -6,7 +6,7 @@ import trw.dbsubsetter.config.Config
 
 import scala.collection.mutable.ArrayBuffer
 
-object DbMetadataQueries {
+private[db] object DbMetadataQueries {
   def queryDb(config: Config): DbMetadataQueryResult = {
     val conn = DriverManager.getConnection(config.originDbConnectionString)
     conn.setReadOnly(true)

--- a/src/main/scala/trw/dbsubsetter/db/Sql.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Sql.scala
@@ -1,6 +1,6 @@
 package trw.dbsubsetter.db
 
-object Sql {
+private[db] object Sql {
   def preparedQueryStatementStrings(sch: SchemaInfo): SqlTemplates = {
     val allCombos = for {
       fk <- sch.fksOrdered

--- a/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
+++ b/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
@@ -8,7 +8,7 @@ import scala.collection.mutable
 /*
  * CAREFUL -- NOT THREADSAFE
  */
-private[primarykeystore] class InMemoryPrimaryKeyStore(schemaInfo: SchemaInfo) extends PrimaryKeyStore {
+private[primarykeystore] final class InMemoryPrimaryKeyStore(schemaInfo: SchemaInfo) extends PrimaryKeyStore {
 
   /*
    * If `seenWithChildrenStorage` contains a PK, then both its children AND its parents have been fetched.

--- a/src/main/scala/trw/dbsubsetter/taskqueue/impl/InMemoryTaskQueueImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/taskqueue/impl/InMemoryTaskQueueImpl.scala
@@ -5,7 +5,7 @@ import trw.dbsubsetter.workflow.OriginDbRequest
 
 import scala.collection.mutable
 
-private[taskqueue] class InMemoryTaskQueueImpl extends TaskQueue {
+private[taskqueue] final class InMemoryTaskQueueImpl extends TaskQueue {
 
   private[this] val queue = mutable.Queue.empty[OriginDbRequest]
 

--- a/src/main/scala/trw/dbsubsetter/taskqueue/impl/TaskQueueInstrumented.scala
+++ b/src/main/scala/trw/dbsubsetter/taskqueue/impl/TaskQueueInstrumented.scala
@@ -4,7 +4,7 @@ import trw.dbsubsetter.metrics.Metrics
 import trw.dbsubsetter.taskqueue.TaskQueue
 import trw.dbsubsetter.workflow.OriginDbRequest
 
-private[taskqueue] class TaskQueueInstrumented(delegatee: TaskQueue) extends TaskQueue {
+private[taskqueue] final class TaskQueueInstrumented(delegatee: TaskQueue) extends TaskQueue {
 
   private[this] val metrics = Metrics.PendingTasksGauge
 

--- a/src/main/scala/trw/dbsubsetter/workflow/FkTaskCreationWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/FkTaskCreationWorkflow.scala
@@ -4,7 +4,7 @@ import trw.dbsubsetter.db._
 
 // TODO reconsider name (or the way this works) since this does not actually create any `FkTask`s. (It creates `NewTasks`).
 // TODO do the same reconsideration for the Akka Streams Flow that calls this.
-class FkTaskCreationWorkflow(schemaInfo: SchemaInfo) {
+final class FkTaskCreationWorkflow(schemaInfo: SchemaInfo) {
 
   def createFkTasks(pksAdded: PksAdded): NewTasks = {
     val PksAdded(table, rowsNeedingParentTasks, rowsNeedingChildTasks, viaTableOpt) = pksAdded

--- a/src/main/scala/trw/dbsubsetter/workflow/OriginDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/OriginDbWorkflow.scala
@@ -4,7 +4,7 @@ import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
 
 
-class OriginDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory) {
+final class OriginDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory) {
 
   private[this] val dbAccess = dbAccessFactory.buildOriginDbAccess()
 

--- a/src/main/scala/trw/dbsubsetter/workflow/PkStoreWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/PkStoreWorkflow.scala
@@ -4,7 +4,7 @@ import trw.dbsubsetter.db.{Row, SchemaInfo, Table}
 import trw.dbsubsetter.primarykeystore.{AlreadySeenWithoutChildren, FirstTimeSeen, PrimaryKeyStore, WriteOutcome}
 
 
-class PkStoreWorkflow(pkStore: PrimaryKeyStore, schemaInfo: SchemaInfo) {
+final class PkStoreWorkflow(pkStore: PrimaryKeyStore, schemaInfo: SchemaInfo) {
 
   private[this] val pkValueExtractionFunctions: Map[Table, Row => Any] =
     PkStoreWorkflow.buildPkValueExtractionFunctions(schemaInfo)

--- a/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
@@ -4,7 +4,7 @@ import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
 
 
-class TargetDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory) {
+final class TargetDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory) {
   private[this] val dbAccess = dbAccessFactory.buildTargetDbAccess()
 
   // The fact that a row still needs parent tasks means this is the first time we've seen it

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFkTaskQueue.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFkTaskQueue.scala
@@ -11,7 +11,7 @@ import trw.dbsubsetter.workflow.offheap.OffHeapFkTaskQueue
 import trw.dbsubsetter.workflow.{ForeignKeyTask, NewTasks, RawTaskToForeignKeyTaskMapper}
 
 
-private[offheap] class ChronicleQueueFkTaskQueue(config: Config, schemaInfo: SchemaInfo) extends OffHeapFkTaskQueue {
+private[offheap] final class ChronicleQueueFkTaskQueue(config: Config, schemaInfo: SchemaInfo) extends OffHeapFkTaskQueue {
 
   private[this] val storageDir = config.taskQueueDirOpt match {
     case Some(dir) => dir.toPath

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import net.openhft.chronicle.wire.ValueIn
 import trw.dbsubsetter.db.{DbVendor, TypeName}
 
-private[offheap] class TaskQueueReader(typeList: Seq[(JDBCType, TypeName)], dbVendor: DbVendor) {
+private[offheap] final class TaskQueueReader(typeList: Seq[(JDBCType, TypeName)], dbVendor: DbVendor) {
   def read(in: ValueIn): Any = handlerFunc(in)
 
   private val handlerFunc: ValueIn => Any = {

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
@@ -7,7 +7,7 @@ import java.util.UUID
 import net.openhft.chronicle.wire.{ValueOut, WireOut, WriteMarshallable}
 import trw.dbsubsetter.db.{DbVendor, TypeName}
 
-private[offheap] class TaskQueueWriter(fkOrdinal: Short, typeList: Seq[(JDBCType, TypeName)], dbVendor: DbVendor) {
+private[offheap] final class TaskQueueWriter(fkOrdinal: Short, typeList: Seq[(JDBCType, TypeName)], dbVendor: DbVendor) {
   def writeHandler(fetchChildren: Boolean, fkValue: Any): WriteMarshallable = {
     wireOut => {
       val out = wireOut.getValueOut


### PR DESCRIPTION
General cleanup to restrict access modifiers and make classes `final` if they should not be overridden.