### PR TITLE
Observability instrument target db buffer size

### DIFF
--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -789,7 +789,7 @@
         "timeFrom": null,
         "timeRegions": [],
         "timeShift": null,
-        "title": "Pre-Target Buffer Entries and Rows (1 entry can have n rows)",
+        "title": "Pre-Target Buffer Entries and Rows (1 Entry Has Many Rows) (Akka Streams Only)",
         "tooltip": {
           "shared": true,
           "sort": 0,

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -776,7 +776,85 @@
             "intervalFactor": 1,
             "legendFormat": "Max Allowed Entries",
             "refId": "B"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Pre-Target Buffer Entries (1 Entry Has Many Rows) (Akka Streams Only)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "none",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
           },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 5,
+          "w": 24,
+          "x": 0,
+          "y": 45
+        },
+        "id": 11,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
           {
             "expr": "PreTargetBufferRows",
             "format": "time_series",
@@ -789,7 +867,7 @@
         "timeFrom": null,
         "timeRegions": [],
         "timeShift": null,
-        "title": "Pre-Target Buffer Entries and Rows (1 Entry Has Many Rows) (Akka Streams Only)",
+        "title": "Pre-Target Buffer Rows (1 Entry Has Many Rows) (Akka Streams Only)",
         "tooltip": {
           "shared": true,
           "sort": 0,

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -726,6 +726,105 @@
           "align": false,
           "alignLevel": null
         }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "fill": 1,
+        "gridPos": {
+          "h": 5,
+          "w": 24,
+          "x": 0,
+          "y": 40
+        },
+        "id": 10,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "PreTargetBufferSize",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Entries",
+            "refId": "A"
+          },
+          {
+            "expr": "PreTargetBufferMaxSize",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Max Allowed Entries",
+            "refId": "B"
+          },
+          {
+            "expr": "PreTargetBufferRows",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Rows",
+            "refId": "C"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Pre-Target Buffer Entries and Rows (1 entry can have n rows)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "none",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
       }
     ],
     "refresh": "5s",

--- a/src/main/scala/trw/dbsubsetter/akkastreams/PreTargetBufferFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/PreTargetBufferFactory.scala
@@ -1,0 +1,38 @@
+package trw.dbsubsetter.akkastreams
+
+import akka.NotUsed
+import akka.stream._
+import akka.stream.scaladsl.{BidiFlow, Flow}
+import trw.dbsubsetter.config.Config
+import trw.dbsubsetter.workflow._
+
+private[akkastreams] object PreTargetBufferFactory {
+
+  def buildPreTargetBuffer(config: Config): Flow[PksAdded, PksAdded, NotUsed] = {
+    var flow: Flow[PksAdded, PksAdded, NotUsed] =
+      Flow[PksAdded].buffer(config.preTargetBufferSize, OverflowStrategy.backpressure)
+
+    if (config.exposeMetrics) {
+      flow = wrapWithInstrumentation(flow)
+    }
+
+    flow
+  }
+
+  private[this] def wrapWithInstrumentation(flow: Flow[PksAdded, PksAdded, NotUsed]): Flow[PksAdded, PksAdded, NotUsed] = {
+    val instrumentFlowEntrance: PksAdded => PksAdded = pksEnteringBuffer => {
+      ???
+      pksEnteringBuffer
+    }
+
+    val instrumentFlowExit: PksAdded => PksAdded = pksExitingBuffer => {
+      ???
+      pksExitingBuffer
+    }
+
+    val wrapper: BidiFlow[PksAdded, PksAdded, PksAdded, PksAdded, NotUsed] =
+      BidiFlow.fromFunctions(instrumentFlowEntrance, instrumentFlowExit)
+
+    flow.join(wrapper)
+  }
+}

--- a/src/main/scala/trw/dbsubsetter/akkastreams/PreTargetBufferFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/PreTargetBufferFactory.scala
@@ -22,21 +22,21 @@ private[akkastreams] object PreTargetBufferFactory {
   }
 
   private[this] def wrapWithInstrumentation(flow: Flow[PksAdded, PksAdded, NotUsed]): Flow[PksAdded, PksAdded, NotUsed] = {
-    val instrumentFlowEntrance: PksAdded => PksAdded = pksEnteringBuffer => {
+    val instrumentEntrance: PksAdded => PksAdded = pksEnteringBuffer => {
       Metrics.PreTargetBufferSizeGauge.inc()
       Metrics.PreTargetBufferRowsGauge.inc(pksEnteringBuffer.rowsNeedingParentTasks.size)
       pksEnteringBuffer
     }
 
-    val instrumentFlowExit: PksAdded => PksAdded = pksExitingBuffer => {
+    val instrumentExit: PksAdded => PksAdded = pksExitingBuffer => {
       Metrics.PreTargetBufferSizeGauge.dec()
       Metrics.PreTargetBufferRowsGauge.dec(pksExitingBuffer.rowsNeedingParentTasks.size)
       pksExitingBuffer
     }
 
     val wrapper: BidiFlow[PksAdded, PksAdded, PksAdded, PksAdded, NotUsed] =
-      BidiFlow.fromFunctions(instrumentFlowEntrance, instrumentFlowExit)
+      BidiFlow.fromFunctions(instrumentEntrance, instrumentExit)
 
-    flow.join(wrapper)
+    wrapper.join(flow)
   }
 }

--- a/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
@@ -3,9 +3,9 @@ package trw.dbsubsetter.akkastreams
 import akka.NotUsed
 import akka.actor.ActorRef
 import akka.pattern.ask
+import akka.stream.SourceShape
 import akka.stream.scaladsl.GraphDSL.Implicits._
 import akka.stream.scaladsl.{Balance, Broadcast, Flow, GraphDSL, Merge, Partition, Source}
-import akka.stream.{OverflowStrategy, SourceShape}
 import akka.util.Timeout
 import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
@@ -76,7 +76,7 @@ object Subsetting {
       fkTaskBufferFlow
 
     broadcastPksAdded ~>
-      Flow[PksAdded].buffer(config.preTargetBufferSize, OverflowStrategy.backpressure) ~>
+      PreTargetBufferFactory.buildPreTargetBuffer(config) ~>
       balanceTargetDb
 
     // FkTasks ~> cannotBePrechecked       ~>        OriginDbRequest

--- a/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
@@ -76,6 +76,7 @@ object Subsetting {
       fkTaskBufferFlow
 
     broadcastPksAdded ~>
+      Flow[PksAdded].filter(_.rowsNeedingParentTasks.nonEmpty) ~>
       PreTargetBufferFactory.buildPreTargetBuffer(config) ~>
       balanceTargetDb
 

--- a/src/main/scala/trw/dbsubsetter/metrics/Metrics.scala
+++ b/src/main/scala/trw/dbsubsetter/metrics/Metrics.scala
@@ -52,6 +52,27 @@ object Metrics {
     .help("n/a")
     .register()
 
+  val PreTargetBufferMaxSizeGauge: Gauge =
+    Gauge
+    .build()
+    .name("PreTargetBufferMaxSize")
+    .help("n/a")
+    .register()
+
+  val PreTargetBufferSizeGauge: Gauge =
+    Gauge
+    .build()
+    .name("PreTargetBufferSize")
+    .help("n/a")
+    .register()
+
+  val PreTargetBufferRowsGauge: Gauge =
+    Gauge
+    .build()
+    .name("PreTargetBufferRows")
+    .help("n/a")
+    .register()
+
   val DuplicateFkTasksDiscarded: Counter =
     Counter
     .build()


### PR DESCRIPTION
Makes progress towards https://github.com/bluerogue251/DBSubsetter/issues/50.

* Adds tracking for number of entries currently in the Target DB Buffer
* Displays the max configured allowed Target DB Buffer Entries for easy comparison to current actual entries (i.e. a way to see if the buffer is "full and currently giving backpressure" or not)
* Adds tracking for number of rows total in the Target DB Buffer (each entry can have many rows)
* Fix a small bug where empty row collections could end up in the Target DB Buffer, filling it up to its max and causing backpressure, where they would just be discarded at the other end of the buffer anyways. Instead, we now discard them prior to entering the buffer.