### PR TITLE
Sql server e2e tests in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -47,6 +47,6 @@ steps:
       - sbt "testOnly unit.* integration.* e2e.*"
 ---
 kind: signature
-hmac: fe87e7d64b35e83869f2046efced460dfe88035e23e0441ffb4e1a18333d7cc4
+hmac: 0df8661b01ae492760d7db2deacaf9e47780549a009f40edaf3b8a5881d8c940
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,6 +8,14 @@ services:
     image: postgres:9.6.3
     command: ["postgres", "-c", "max_connections=200"]
 
+  - name: e2e_sql_server
+    image: microsoft/mssql-server-linux:2017-CU12
+    environment:
+      SA_PASSWORD: "MsSqlServerLocal1"
+      MSSQL_PID: "Developer"
+      ACCEPT_EULA: "Y"
+    command: ["/opt/mssql/bin/sqlservr"]
+
   - name: mysql_origin
     image: mysql:8.0.3
     environment:
@@ -23,11 +31,14 @@ services:
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
 
+
+
 steps:
   - name: test
     image: bluerogue251/db-subsetter-ci:2
     environment:
       DB_SUBSETTER_POSTGRES_HOST: postgres
+      DB_SUBSETTER_SQL_SERVER_HOST: sql_server
       DB_SUBSETTER_MYSQL_ORIGIN_HOST: mysql_origin
       DB_SUBSETTER_MYSQL_TARGET_SINGLE_THREADED_HOST: mysql_target_single_threaded
       DB_SUBSETTER_MYSQL_TARGET_AKKA_STREAMS_HOST: mysql_target_akka_streams

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,10 +9,10 @@ services:
     command: ["postgres", "-c", "max_connections=200"]
 
   - name: sql_server
-    image: microsoft/mssql-server-linux:2017-CU12
+    image: microsoft/mssql-server-linux:2017-CU14-ubuntu
     environment:
       SA_PASSWORD: "MsSqlServerLocal1"
-      MSSQL_PID: "Standard"
+      MSSQL_PID: "Developer"
       ACCEPT_EULA: "Y"
     command: ["/opt/mssql/bin/sqlservr"]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -48,6 +48,6 @@ steps:
       - sbt "testOnly unit.* integration.* e2e.*"
 ---
 kind: signature
-hmac: 6a2557692491fff2aa472f296545e9fd783fd09440190f796c1ea578298ea891
+hmac: 2a2ac9181c49b42ab8183c31d060e9f1b977e9b9cf2d72d562130e9d346eb892
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ services:
     command: ["postgres", "-c", "max_connections=200"]
 
   - name: sql_server
-    image: microsoft/mssql-server-linux:2017-CU12
+    image: microsoft/mssql-server-windows-developer
     environment:
       SA_PASSWORD: "MsSqlServerLocal1"
       MSSQL_PID: "Developer"
@@ -47,6 +47,6 @@ steps:
       - sbt "testOnly unit.* integration.* e2e.*"
 ---
 kind: signature
-hmac: c9ec6734cfe52425c964fe6706aabf9ec68125b2260bc9a659220ae830cf205b
+hmac: 28f67f038d9332fb0f18ded58b44154d7c3b5f241034ab3a2ebb34706bb52dc7
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -43,10 +43,11 @@ steps:
       DB_SUBSETTER_MYSQL_ORIGIN_PORT: 3306
       DB_SUBSETTER_MYSQL_TARGET_SINGLE_THREADED_PORT: 3306
       DB_SUBSETTER_MYSQL_TARGET_AKKA_STREAMS_PORT: 3306
+      LC_ALL: en_US.UTF-8
     commands:
-      - sbt "testOnly unit.* integration.* e2e.*PostgreSQL e2e.*MySql e2e.pgdatatypes.* e2e.mysqldatatypes.*"
+      - sbt "testOnly unit.* integration.* e2e.*"
 ---
 kind: signature
-hmac: c5dfba22307ad91a6b3d1d9ca264f62416486fd2536a9b8135001bd3c6ac73dc
+hmac: 6a2557692491fff2aa472f296545e9fd783fd09440190f796c1ea578298ea891
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -33,7 +33,7 @@ services:
 
 steps:
   - name: test
-    image: bluerogue251/db-subsetter-ci:3
+    image: bluerogue251/db-subsetter-ci:4
     environment:
       DB_SUBSETTER_POSTGRES_HOST: postgres
       DB_SUBSETTER_SQL_SERVER_HOST: sql_server
@@ -43,11 +43,10 @@ steps:
       DB_SUBSETTER_MYSQL_ORIGIN_PORT: 3306
       DB_SUBSETTER_MYSQL_TARGET_SINGLE_THREADED_PORT: 3306
       DB_SUBSETTER_MYSQL_TARGET_AKKA_STREAMS_PORT: 3306
-      LC_ALL: en_US.UTF-8
     commands:
       - sbt "testOnly unit.* integration.* e2e.*"
 ---
 kind: signature
-hmac: 2a2ac9181c49b42ab8183c31d060e9f1b977e9b9cf2d72d562130e9d346eb892
+hmac: fe87e7d64b35e83869f2046efced460dfe88035e23e0441ffb4e1a18333d7cc4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ services:
     command: ["postgres", "-c", "max_connections=200"]
 
   - name: sql_server
-    image: microsoft/mssql-server-windows-developer
+    image: microsoft/mssql-server-linux:2017-CU12
     environment:
       SA_PASSWORD: "MsSqlServerLocal1"
       MSSQL_PID: "Developer"
@@ -47,6 +47,6 @@ steps:
       - sbt "testOnly unit.* integration.* e2e.*"
 ---
 kind: signature
-hmac: 28f67f038d9332fb0f18ded58b44154d7c3b5f241034ab3a2ebb34706bb52dc7
+hmac: c9ec6734cfe52425c964fe6706aabf9ec68125b2260bc9a659220ae830cf205b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,11 +31,9 @@ services:
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "true"
 
-
-
 steps:
   - name: test
-    image: bluerogue251/db-subsetter-ci:2
+    image: bluerogue251/db-subsetter-ci:3
     environment:
       DB_SUBSETTER_POSTGRES_HOST: postgres
       DB_SUBSETTER_SQL_SERVER_HOST: sql_server
@@ -49,6 +47,6 @@ steps:
       - sbt "testOnly unit.* integration.* e2e.*PostgreSQL e2e.*MySql e2e.pgdatatypes.* e2e.mysqldatatypes.*"
 ---
 kind: signature
-hmac: 17c870c36a9990687dc120f816e0f095254d598829eef3f063e8b44d8fe1b17d
+hmac: cebed815ff636f303a38a2261c652a979230589570d2025075955c1a282e7388
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,9 +44,9 @@ steps:
       DB_SUBSETTER_MYSQL_TARGET_SINGLE_THREADED_PORT: 3306
       DB_SUBSETTER_MYSQL_TARGET_AKKA_STREAMS_PORT: 3306
     commands:
-      - sbt "testOnly e2e.*SqlServer"
+      - sbt "testOnly unit.* integration.* e2e.*PostgreSQL e2e.*MySql e2e.pgdatatypes.* e2e.mysqldatatypes.*"
 ---
 kind: signature
-hmac: 106f644a2e123871eb4012bfceff93c34a01401d61089c0c35053f90000b17d1
+hmac: c5dfba22307ad91a6b3d1d9ca264f62416486fd2536a9b8135001bd3c6ac73dc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,9 +44,9 @@ steps:
       DB_SUBSETTER_MYSQL_TARGET_SINGLE_THREADED_PORT: 3306
       DB_SUBSETTER_MYSQL_TARGET_AKKA_STREAMS_PORT: 3306
     commands:
-      - sbt "testOnly unit.* integration.* e2e.*"
+      - sbt "testOnly e2e.*SqlServer"
 ---
 kind: signature
-hmac: c9ec6734cfe52425c964fe6706aabf9ec68125b2260bc9a659220ae830cf205b
+hmac: 106f644a2e123871eb4012bfceff93c34a01401d61089c0c35053f90000b17d1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,9 +44,9 @@ steps:
       DB_SUBSETTER_MYSQL_TARGET_SINGLE_THREADED_PORT: 3306
       DB_SUBSETTER_MYSQL_TARGET_AKKA_STREAMS_PORT: 3306
     commands:
-      - sbt "testOnly unit.* integration.* e2e.*PostgreSQL e2e.*MySql e2e.pgdatatypes.* e2e.mysqldatatypes.*"
+      - sbt "testOnly unit.* integration.* e2e.*"
 ---
 kind: signature
-hmac: cebed815ff636f303a38a2261c652a979230589570d2025075955c1a282e7388
+hmac: 338ab38787bb6af7565a4f48eb38475f073bd357ea01429af5bff200e8707b85
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ services:
     image: postgres:9.6.3
     command: ["postgres", "-c", "max_connections=200"]
 
-  - name: e2e_sql_server
+  - name: sql_server
     image: microsoft/mssql-server-linux:2017-CU12
     environment:
       SA_PASSWORD: "MsSqlServerLocal1"
@@ -47,6 +47,6 @@ steps:
       - sbt "testOnly unit.* integration.* e2e.*"
 ---
 kind: signature
-hmac: 338ab38787bb6af7565a4f48eb38475f073bd357ea01429af5bff200e8707b85
+hmac: c9ec6734cfe52425c964fe6706aabf9ec68125b2260bc9a659220ae830cf205b
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ services:
     image: microsoft/mssql-server-linux:2017-CU12
     environment:
       SA_PASSWORD: "MsSqlServerLocal1"
-      MSSQL_PID: "Developer"
+      MSSQL_PID: "Standard"
       ACCEPT_EULA: "Y"
     command: ["/opt/mssql/bin/sqlservr"]
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -9,7 +9,7 @@ services:
     command: ["postgres", "-c", "max_connections=200"]
 
   - name: sql_server
-    image: microsoft/mssql-server-linux:2017-CU14-ubuntu
+    image: mcr.microsoft.com/mssql/server:2017-CU14-ubuntu
     environment:
       SA_PASSWORD: "MsSqlServerLocal1"
       MSSQL_PID: "Developer"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apk add --no-cache postgresql-client
 
 RUN apk add --no-cache mysql-client
 
+# Somehow install SQL Server Tools
+
 RUN apk add --no-cache --virtual=build-dependencies curl
 
 RUN curl -sL "https://piccolo.link/sbt-1.0.4.tgz" | gunzip | tar -x -C /usr/local && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,27 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jdk-stretch
 
-RUN apk add --no-cache bash
+RUN apt-get update
+RUN apt-get upgrade -y
 
-RUN apk add --no-cache postgresql-client
+RUN apt-get install -y postgresql-client
 
-RUN apk add --no-cache mysql-client
+RUN apt-get install -y mysql-client
 
-# Somehow install SQL Server Tools
+# Install some pre-requisites to HTTPS usage in certain apt functions
+RUN apt-get install -y apt-transport-https ca-certificates
 
-RUN apk add --no-cache --virtual=build-dependencies curl
+# Install SQL Server Tools
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
+RUN curl https://packages.microsoft.com/config/ubuntu/16.04/prod.list | tee /etc/apt/sources.list.d/msprod.list
+RUN apt-get update
+ENV ACCEPT_EULA Y
+RUN apt-get install -y mssql-tools unixodbc-dev
 
-RUN curl -sL "https://piccolo.link/sbt-1.0.4.tgz" | gunzip | tar -x -C /usr/local && \
-    ln -s /usr/local/sbt/bin/sbt /usr/local/bin/sbt && \
-    chmod 0755 /usr/local/bin/sbt && \
-    apk del build-dependencies
+# Install SBT
+RUN echo "deb https://dl.bintray.com/sbt/debian /" | tee -a /etc/apt/sources.list.d/sbt.list
+RUN curl -sL "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x2EE0EA64E40A89B84B2DF73499E82A75642AC823" | apt-key add
+RUN apt-get update
+RUN apt-get install -y sbt
 
 # Eagerly prime SBT and download project dependencies to speed up builds on CI
 ADD . /tmp-project-install

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,9 @@ WORKDIR /tmp-project-install
 RUN sbt compile
 WORKDIR root
 run rm -rf /tmp-project-install
+
+# https://github.com/Microsoft/mssql-docker/issues/163
+RUN apt-get install -y locales
+RUN echo "nb_NO.UTF-8 UTF-8" > /etc/locale.gen
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN locale-gen

--- a/build.sbt
+++ b/build.sbt
@@ -33,5 +33,3 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.2.1" % "test",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.2.1" % "test"
 )
-
-parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -33,3 +33,7 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.2.1" % "test",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.2.1" % "test"
 )
+
+// Unfortunately SqlServer tests are flaky when run in parallel
+// TODO remove this and re-enable parallel tests
+parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -33,3 +33,6 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.2.1" % "test",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.2.1" % "test"
 )
+
+// Try to get around flaky SQL Server tests
+parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -33,3 +33,5 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.2.1" % "test",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.2.1" % "test"
 )
+
+parallelExecution in Test := false

--- a/build.sbt
+++ b/build.sbt
@@ -33,6 +33,3 @@ libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.2.1" % "test",
   "com.typesafe.slick" %% "slick-hikaricp" % "3.2.1" % "test"
 )
-
-// Try to get around flaky SQL Server tests
-parallelExecution in Test := false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "5432:5432"
 
   e2e_sql_server:
-    image: microsoft/mssql-server-linux:2017-CU12
+    image: microsoft/mssql-server-windows-developer
     environment:
       SA_PASSWORD: "MsSqlServerLocal1"
       MSSQL_PID: "Developer"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,16 @@ services:
     ports:
       - "5432:5432"
 
+  e2e_sql_server:
+    image: microsoft/mssql-server-linux:2017-CU12
+    environment:
+      SA_PASSWORD: "MsSqlServerLocal1"
+      MSSQL_PID: "Developer"
+      ACCEPT_EULA: "Y"
+    command: /opt/mssql/bin/sqlservr
+    ports:
+      - "1433:1433"
+
   mysql_origin:
     image: mysql:8.0.3
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - "5432:5432"
 
   e2e_sql_server:
-    image: microsoft/mssql-server-windows-developer
+    image: microsoft/mssql-server-linux:2017-CU12
     environment:
       SA_PASSWORD: "MsSqlServerLocal1"
       MSSQL_PID: "Developer"

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -26,6 +26,7 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
 
   override protected def containers: DatabaseContainerSet[SqlServerDatabase] = {
     val containerName = SharedTestContainers.sqlServer.name
+    val host = SharedTestContainers.sqlServer.db.host
     val port = SharedTestContainers.sqlServer.db.port
     val originDbName = s"${testName}_origin"
     val targetSingleThreadedDbName = s"${testName}_target_single_threaded"
@@ -43,21 +44,21 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
   override protected def prepareOriginDML(): Unit
 
   override protected def prepareTargetDDL(): Unit = {
-    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.name} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
+    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
     s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.name} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
   }
 
   override protected def postSubset(): Unit = {
-    s"./src/test/util/sqlserver_post_subset.sh ${containers.origin.name} ${containers.targetSingleThreaded.db.name}".!!
-    s"./src/test/util/sqlserver_post_subset.sh ${containers.origin.name} ${containers.targetAkkaStreams.db.name}".!!
+    s"./src/test/util/sqlserver_post_subset.sh ${containers.origin.db.host} ${containers.targetSingleThreaded.db.name}".!!
+    s"./src/test/util/sqlserver_post_subset.sh ${containers.origin.db.host} ${containers.targetAkkaStreams.db.name}".!!
   }
 
   private def createEmptyDb(containerName: String, dbName: String): Unit = {
-    s"./src/test/util/create_sqlserver_db.sh $containerName $dbName".!!
+    s"./src/test/util/create_sqlserver_db.sh ${containers.origin.db.host} $dbName".!!
   }
 
-  private def buildContainer(containerName: String, dbName: String, dbPort: Int): SqlServerContainer = {
-    val db: SqlServerDatabase = new SqlServerDatabase(dbName, dbPort)
-    new SqlServerContainer(containerName, db)
+  private def buildContainer(dbHost: String, dbName: String, dbPort: Int): SqlServerContainer = {
+    val db: SqlServerDatabase = new SqlServerDatabase(dbHost, dbName, dbPort)
+    new SqlServerContainer(SharedTestContainers.sqlServer.name, db)
   }
 }

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -22,6 +22,7 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
   override protected def createTargetDatabases(): Unit = {
     createEmptyDb(containers.origin.name, containers.targetSingleThreaded.db.name)
     createEmptyDb(containers.origin.name, containers.targetAkkaStreams.db.name)
+    Thread.sleep(2000) // Try to get around flaky SqlServer tests
   }
 
   override protected def containers: DatabaseContainerSet[SqlServerDatabase] = {

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -9,11 +9,11 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
 
   protected def testName: String
 
-  override protected def startOriginContainer():Unit = SharedTestContainers.sqlServer
+  override protected def startOriginContainer():Unit = {} // No-op
 
   override protected def startTargetContainers(): Unit = {} // No-op (container is shared with origin)
 
-  override protected def awaitContainersReady(): Unit = SharedTestContainers.awaitSqlServerUp
+  override protected def awaitContainersReady(): Unit = {} // No-op
 
   override protected def createOriginDatabase(): Unit = {
     createEmptyDb(containers.origin.name, containers.origin.db.name)

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -25,7 +25,6 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
   }
 
   override protected def containers: DatabaseContainerSet[SqlServerDatabase] = {
-    val containerName = SharedTestContainers.sqlServer.name
     val host = SharedTestContainers.sqlServer.db.host
     val port = SharedTestContainers.sqlServer.db.port
     val originDbName = s"${testName}_origin"

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -33,9 +33,9 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
     val targetAkkaStreamsDbName = s"${testName}_target_akka_streams"
 
     new DatabaseContainerSet(
-      buildContainer(containerName, originDbName, port),
-      buildContainer(containerName, targetSingleThreadedDbName, port),
-      buildContainer(containerName, targetAkkaStreamsDbName, port)
+      buildContainer(host, originDbName, port),
+      buildContainer(host, targetSingleThreadedDbName, port),
+      buildContainer(host, targetAkkaStreamsDbName, port)
     )
   }
 
@@ -45,7 +45,7 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
 
   override protected def prepareTargetDDL(): Unit = {
     s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
-    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.name} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
+    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
   }
 
   override protected def postSubset(): Unit = {

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -2,7 +2,6 @@ package e2e
 
 import util.db._
 
-import scala.annotation.tailrec
 import scala.sys.process._
 
 abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlServerDatabase] {
@@ -44,20 +43,8 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
   override protected def prepareOriginDML(): Unit
 
   override protected def prepareTargetDDL(): Unit = {
-    @tailrec
-    def doSync(i: Int): Unit = {
-      if (i < 5) {
-        try {
-          s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
-          s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
-        } catch {
-          case e: RuntimeException =>
-            Thread.sleep(500) // Trying to make this fail less often :-/
-            doSync(i + 1)
-        }
-      }
-    }
-    doSync(0)
+    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
+    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
   }
 
   override protected def postSubset(): Unit = {

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -2,6 +2,7 @@ package e2e
 
 import util.db._
 
+import scala.annotation.tailrec
 import scala.sys.process._
 
 abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlServerDatabase] {
@@ -43,9 +44,20 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
   override protected def prepareOriginDML(): Unit
 
   override protected def prepareTargetDDL(): Unit = {
-    Thread.sleep(1000) // Try to make parallel tests a little more reliable?
-    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
-    s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
+    @tailrec
+    def doSync(i: Int): Unit = {
+      if (i < 5) {
+        try {
+          s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
+          s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
+        } catch {
+          case e: RuntimeException =>
+            Thread.sleep(500) // Trying to make this fail less often :-/
+            doSync(i + 1)
+        }
+      }
+    }
+    doSync(0)
   }
 
   override protected def postSubset(): Unit = {

--- a/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
+++ b/src/test/scala/e2e/AbstractSqlServerEndToEndTest.scala
@@ -43,6 +43,7 @@ abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlSer
   override protected def prepareOriginDML(): Unit
 
   override protected def prepareTargetDDL(): Unit = {
+    Thread.sleep(1000) // Try to make parallel tests a little more reliable?
     s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetSingleThreaded.db.name}".!!
     s"./src/test/util/sync_sqlserver_origin_to_target.sh ${containers.origin.db.host} ${containers.origin.db.name} ${containers.targetAkkaStreams.db.name}".!!
   }

--- a/src/test/scala/e2e/SharedTestContainers.scala
+++ b/src/test/scala/e2e/SharedTestContainers.scala
@@ -2,7 +2,6 @@ package e2e
 
 import util.Ports
 import util.db._
-import util.docker.ContainerUtil
 
 import scala.util.Properties
 
@@ -18,18 +17,10 @@ object SharedTestContainers {
   }
 
   lazy val sqlServer: SqlServerContainer = {
-    val containerName = "e2e_sql_server"
+    val containerName = "dbsubsetter_e2e_sql_server_1"
     val port = Ports.sharedSqlServerPort
-    DatabaseContainer.recreateSqlServer(containerName, port)
     val db = new SqlServerDatabase(dbName, port)
-
-    /*
-     * Remove container on JVM shutdown
-     */
-    sys.addShutdownHook(ContainerUtil.rm(containerName))
 
     new SqlServerContainer(containerName, db)
   }
-
-  lazy val awaitSqlServerUp: Unit = Thread.sleep(6000)
 }

--- a/src/test/scala/e2e/SharedTestContainers.scala
+++ b/src/test/scala/e2e/SharedTestContainers.scala
@@ -17,10 +17,10 @@ object SharedTestContainers {
   }
 
   lazy val sqlServer: SqlServerContainer = {
-    val containerName = "dbsubsetter_e2e_sql_server_1"
+    val containerName = "placeholder-do-not-use"
+    val dbHost: String = Properties.envOrElse("DB_SUBSETTER_SQL_SERVER_HOST", "localhost")
     val port = Ports.sharedSqlServerPort
-    val db = new SqlServerDatabase(dbName, port)
-
+    val db = new SqlServerDatabase(dbHost, dbName, port)
     new SqlServerContainer(containerName, db)
   }
 }

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestSqlServer.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestSqlServer.scala
@@ -12,9 +12,9 @@ class CrossSchemaTestSqlServer extends AbstractSqlServerEndToEndTest with CrossS
   )
 
   override protected def prepareOriginDDL(): Unit = {
-    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_1".!!
-    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_2".!!
-    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.name} ${containers.origin.db.name} schema_3".!!
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.db.host} ${containers.origin.db.name} schema_1".!!
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.db.host} ${containers.origin.db.name} schema_2".!!
+    s"./src/test/util/create_schema_sqlserver.sh ${containers.origin.db.host} ${containers.origin.db.name} schema_3".!!
     super.prepareOriginDDL()
   }
 }

--- a/src/test/scala/util/Ports.scala
+++ b/src/test/scala/util/Ports.scala
@@ -2,7 +2,7 @@ package util
 
 object Ports {
   val sharedPostgresPort: Int = 5432
-  val sharedSqlServerPort: Int = 5496
+  val sharedSqlServerPort: Int = 1433
   val sharedMySqlOriginPort: Int = 3306
   val sharedMySqlTargetSingleThreadedPort: Int = 3307
   val sharedMySqlTargetAkkaStreamsPort: Int = 3308

--- a/src/test/scala/util/db/Database.scala
+++ b/src/test/scala/util/db/Database.scala
@@ -14,6 +14,6 @@ class PostgreSQLDatabase(val host: String, val port: Int, val name: String) exte
   override def connectionString: String = s"jdbc:postgresql://$host:$port/$name?user=postgres"
 }
 
-class SqlServerDatabase(val name: String, val port: Int) extends Database {
-  override def connectionString: String = s"jdbc:sqlserver://localhost:$port;databaseName=$name;user=sa;password=MsSqlServerLocal1"
+class SqlServerDatabase(val host: String, val name: String, val port: Int) extends Database {
+  override def connectionString: String = s"jdbc:sqlserver://$host:$port;databaseName=$name;user=sa;password=MsSqlServerLocal1"
 }

--- a/src/test/scala/util/db/DatabaseContainer.scala
+++ b/src/test/scala/util/db/DatabaseContainer.scala
@@ -1,20 +1,8 @@
 package util.db
 
-import util.docker.ContainerUtil
-
-import scala.sys.process._
-
 trait DatabaseContainer[T <: Database] {
   def name: String
   def db: T
-}
-
-object DatabaseContainer {
-  def recreateSqlServer(name: String, port: Int): Unit = {
-    ContainerUtil.rm(name)
-    s"docker create --name $name -p $port:1433 --env ACCEPT_EULA=Y --env SA_PASSWORD=MsSqlServerLocal1 --env MSSQL_PID=Developer microsoft/mssql-server-linux:2017-CU12 /opt/mssql/bin/sqlservr".!!
-    ContainerUtil.start(name)
-  }
 }
 
 class MySqlContainer(val name: String, val db: MySqlDatabase) extends DatabaseContainer[MySqlDatabase]

--- a/src/test/scala/util/docker/ContainerUtil.scala
+++ b/src/test/scala/util/docker/ContainerUtil.scala
@@ -3,10 +3,6 @@ package util.docker
 import scala.sys.process._
 
 object ContainerUtil {
-  def rm(name: String): Unit = {
-    s"docker rm --force --volumes $name".!
-  }
-
   def start(name: String): Unit = {
     s"docker start $name".!
   }

--- a/src/test/util/create_schema_sqlserver.sh
+++ b/src/test/util/create_schema_sqlserver.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -eou pipefail
 
-container_name=$1
+host=$1
 db_name=$2
 schema_name=$3
 
-docker exec ${container_name} /opt/mssql-tools/bin/sqlcmd -U sa -P MsSqlServerLocal1 -d ${db_name} -Q "create schema [$schema_name];"
+/opt/mssql-tools/bin/sqlcmd -S ${host} -U sa -P MsSqlServerLocal1 -d ${db_name} -Q "create schema [$schema_name];"

--- a/src/test/util/create_sqlserver_db.sh
+++ b/src/test/util/create_sqlserver_db.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-container_name=$1
+host=$1
 db_name=$2
 
-docker exec ${container_name} /opt/mssql-tools/bin/sqlcmd -U sa -P MsSqlServerLocal1 -Q "create database [$db_name];"
+/opt/mssql-tools/bin/sqlcmd -S ${host} -U sa -P MsSqlServerLocal1 -Q "create database [$db_name];"

--- a/src/test/util/create_sqlserver_db.sh
+++ b/src/test/util/create_sqlserver_db.sh
@@ -5,4 +5,4 @@ set -eou pipefail
 host=$1
 db_name=$2
 
-/opt/mssql-tools/bin/sqlcmd -S ${host} -U sa -P MsSqlServerLocal1 -Q "create database [$db_name];"
+/opt/mssql-tools/bin/sqlcmd -S "${host}" -U sa -P MsSqlServerLocal1 -Q "create database [$db_name];"

--- a/src/test/util/sqlserver_post_subset.sh
+++ b/src/test/util/sqlserver_post_subset.sh
@@ -2,7 +2,7 @@
 
 set -eou pipefail
 
-container_name=$1
+host=$1
 target_db_name=$2
 
-docker exec ${container_name} /opt/mssql-tools/bin/sqlcmd -U sa -P MsSqlServerLocal1 -d ${target_db_name} -Q "EXEC sp_msforeachtable 'ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all'"
+/opt/mssql-tools/bin/sqlcmd -S ${host} -U sa -P MsSqlServerLocal1 -d ${target_db_name} -Q "EXEC sp_msforeachtable 'ALTER TABLE ? WITH CHECK CHECK CONSTRAINT all'"

--- a/src/test/util/sync_sqlserver_origin_to_target.sh
+++ b/src/test/util/sync_sqlserver_origin_to_target.sh
@@ -2,11 +2,11 @@
 
 set -eou pipefail
 
-container_name=$1
+host=$1
 origin_db_name=$2
 target_db_name=$3
 
-docker exec ${container_name} /opt/mssql-tools/bin/sqlcmd -U sa -P MsSqlServerLocal1 -Q "drop database if exists $target_db_name"
-docker exec ${container_name} /opt/mssql-tools/bin/sqlcmd -U sa -P MsSqlServerLocal1 -Q "DBCC clonedatabase ($origin_db_name, $target_db_name) with no_statistics, no_querystore"
-docker exec ${container_name} /opt/mssql-tools/bin/sqlcmd -U sa -P MsSqlServerLocal1 -Q "alter database $target_db_name set read_write"
-docker exec ${container_name} /opt/mssql-tools/bin/sqlcmd -U sa -P MsSqlServerLocal1 -d ${target_db_name} -Q "EXEC sp_msforeachtable 'ALTER TABLE ? NOCHECK CONSTRAINT all'"
+/opt/mssql-tools/bin/sqlcmd -S "${host}" -U sa -P MsSqlServerLocal1 -Q "drop database if exists $target_db_name"
+/opt/mssql-tools/bin/sqlcmd -S "${host}" -U sa -P MsSqlServerLocal1 -Q "DBCC clonedatabase ($origin_db_name, $target_db_name) with no_statistics, no_querystore"
+/opt/mssql-tools/bin/sqlcmd -S "${host}" -U sa -P MsSqlServerLocal1 -Q "alter database $target_db_name set read_write"
+/opt/mssql-tools/bin/sqlcmd -S "${host}" -U sa -P MsSqlServerLocal1 -d ${target_db_name} -Q "EXEC sp_msforeachtable 'ALTER TABLE ? NOCHECK CONSTRAINT all'"


### PR DESCRIPTION
Progress towards https://github.com/bluerogue251/DBSubsetter/issues/42

Enables running of e2e tests for SqlServer on Drone

SqlServer tests appear kind of flaky, so unfortunately to make them less flaky I had to disable parallel tests :-(. Hopefully I will eventually turn back on parallelism.