### PR TITLE
Remove skipPkStore option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,7 @@ $ java -jar /path/to/DBSubsetter.jar \
 
 Memory usage in the worst case will be proportional to the sum of:
 
-* The size of all primary keys in the target database. (But depending on your 
-  schema structure, you may be able to use the `--skipPkStore` option to
-  configure DBSubsetter to use just a small fraction of that amount.)
+* The size of all primary keys in the target database.
 * The size of your largest single query result multiplied by 
   (`--originDbParallelism` + `--targetDbParallelism` + `--preTargetBufferSize`)
 

--- a/load-test/4-run.sh
+++ b/load-test/4-run.sh
@@ -31,7 +31,7 @@ java -Xmx4G -jar DBSubsetter.jar \
 echo "Sleeping 90 seconds to make a clear boundary in metrics"
 sleep 90
 
-# TODO: fix so that some experiment plans have no scientist. Then use this base query to test auto-skipPkStore calculations
+# TODO: fix so that some experiment plans have no scientist. Then consider using this base query.
 # "--baseQuery", "public.experiment_plans ::: id % 35 = 0 ::: includeChildren",
 echo "Running load test of physics_db"
 nohup java -Xmx4G -jar DBSubsetter.jar \
@@ -44,9 +44,4 @@ nohup java -Xmx4G -jar DBSubsetter.jar \
   --excludeTable "public.particle_domain" \
   --excludeTable "public.quantum_domain" \
   --excludeTable "public.gravitational_wave_domain" \
-  --skipPkStore "public.datum_note_responses" \
-  --skipPkStore "public.datum_notes" \
-  --skipPkStore "public.gravitational_wave_data" \
-  --skipPkStore "public.particle_collider_data" \
-  --skipPkStore "public.quantum_data" \
   --exposeMetrics &

--- a/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
+++ b/src/main/scala/trw/dbsubsetter/ApplicationSingleThreaded.scala
@@ -30,7 +30,7 @@ object ApplicationSingleThreaded {
       }
       taskOpt.foreach { task =>
         val dbResult = originDbWorkflow.process(task)
-        val pksAdded = if (dbResult.table.storePks) pkWorkflow.add(dbResult) else SkipPkStore.process(dbResult)
+        val pksAdded = pkWorkflow.add(dbResult)
         targetDbWorkflow.process(pksAdded)
         val newTasks = fkTaskCreationWorkflow.createFkTasks(pksAdded)
         newTasks.taskInfo.foreach { case ((foreignKey, fetchChildren), fkValues) =>

--- a/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
@@ -22,7 +22,6 @@ object Subsetting {
     val mergeOriginDbRequests = b.add(Merge[OriginDbRequest](3))
     val balanceOriginDb = b.add(Balance[OriginDbRequest](config.originDbParallelism, waitForAllDownstreams = true))
     val mergeOriginDbResults = b.add(Merge[OriginDbResult](config.originDbParallelism))
-    val partitionOriginDbResults = b.add(Partition[OriginDbResult](2, res => if (res.table.storePks) 1 else 0))
     val partitionFkTasks = b.add(Partition[ForeignKeyTask](2, {
       case t: FetchParentTask => if (FkTaskPreCheck.shouldPrecheck(t)) 1 else 0
       case _ => 0
@@ -51,16 +50,7 @@ object Subsetting {
       balanceTargetDb ~> TargetDb.insert(config, schemaInfo, dbAccessFactory).async ~> mergeTargetDbResults
     }
 
-    // Origin DB Results ~> PkStoreAdd  ~> |merge| ~> NewTasks
-    //                   ~> SkipPkStore ~> |merge| ~> TargetDbInserts
     mergeOriginDbResults ~>
-      partitionOriginDbResults
-
-    partitionOriginDbResults.out(0) ~>
-      Flow[OriginDbResult].map(SkipPkStore.process) ~>
-      mergePksAdded
-
-    partitionOriginDbResults.out(1) ~>
       Flow[OriginDbResult].mapAsyncUnordered(10)(dbResult => (pkStore ? dbResult).mapTo[PksAdded]) ~>
       mergePksAdded
 

--- a/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
+++ b/src/main/scala/trw/dbsubsetter/akkastreams/Subsetting.scala
@@ -28,7 +28,6 @@ object Subsetting {
     }))
     // TODO try to turn this broadcast into a typesafe Partition stage with two output ports, each output port with a different type
     val broadcastPkExistResult = b.add(Broadcast[PkQueryResult](2))
-    val mergePksAdded = b.add(Merge[PksAdded](2))
     val broadcastPksAdded = b.add(Broadcast[PksAdded](2))
     val balanceTargetDb = b.add(Balance[PksAdded](config.targetDbParallelism, waitForAllDownstreams = true))
     val mergeTargetDbResults = b.add(Merge[TargetDbInsertResult](config.targetDbParallelism))
@@ -52,9 +51,6 @@ object Subsetting {
 
     mergeOriginDbResults ~>
       Flow[OriginDbResult].mapAsyncUnordered(10)(dbResult => (pkStore ? dbResult).mapTo[PksAdded]) ~>
-      mergePksAdded
-
-    mergePksAdded ~>
       broadcastPksAdded
 
     broadcastPksAdded ~>

--- a/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
+++ b/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
@@ -154,25 +154,6 @@ object CommandLineParser {
           |                           Can be specified multiple times
           |""".stripMargin)
 
-    opt[String]("skipPkStore")
-      .valueName("<schema>.<table>")
-      .maxOccurs(Int.MaxValue)
-      .action { (str, c) =>
-        val regex = """^\s*(.+)\.(.+)\s*$""".r
-        str match {
-          case regex(schema, table) => c.copy(skipPkStore = c.skipPkStore ++ Set((schema, table)))
-          case _ => throw new RuntimeException()
-        }
-      }.text(
-      """Skip runtime in-memory storage for a table's primary keys
-        |                           For large tables, this can significantly reduce DBSubsetter's memory footprint.
-        |                           This currently is not well documented. It involves understanding how DBSubsetter
-        |                           works and knowing that a given table's rows will all only be processed once.
-        |                           Feel free to open a GitHub ticket to ask for more information about this.
-        |                           A future release of DBSubsetter will hopefully automate this.
-        |                           Can be specified multiple times
-        |""".stripMargin)
-
     opt[Int]("preTargetBufferSize")
       .valueName("<int>")
       .action((int, c) => c.copy(preTargetBufferSize = int))

--- a/src/main/scala/trw/dbsubsetter/config/Config.scala
+++ b/src/main/scala/trw/dbsubsetter/config/Config.scala
@@ -15,7 +15,6 @@ case class Config(
   cmdLinePrimaryKeys: List[CmdLinePrimaryKey] = List.empty,
   excludeColumns: Map[(SchemaName, TableName), Set[ColumnName]] = Map.empty.withDefaultValue(Set.empty),
   excludeTables: Set[(SchemaName, TableName)] = Set.empty,
-  skipPkStore: Set[(SchemaName, TableName)] = Set.empty,
   preTargetBufferSize: Int = 100,
   taskQueueDirOpt: Option[File] = None,
   isSingleThreadedDebugMode: Boolean = false,

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -10,8 +10,7 @@ object SchemaInfoRetrieval {
 
     val tablesByName = tables.map { t =>
       val hasSqlServerAutoincrement = columns.exists(c => c.schema == t.schema && c.table == t.name && c.isSqlServerAutoincrement)
-      val storePks = !config.skipPkStore.contains((t.schema, t.name))
-      (t.schema, t.name) -> new Table(t.schema, t.name, hasSqlServerAutoincrement, storePks)
+      (t.schema, t.name) -> new Table(t.schema, t.name, hasSqlServerAutoincrement)
     }.toMap
 
     val colsByTableAndName: Map[Table, Map[ColumnName, Column]] = {

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -25,8 +25,7 @@ package object db {
   class Table(
     val schema: SchemaName,
     val name: TableName,
-    val hasSqlServerAutoIncrement: Boolean,
-    val storePks: Boolean
+    val hasSqlServerAutoIncrement: Boolean
   )
 
   class Column(

--- a/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
+++ b/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
@@ -65,7 +65,7 @@ private[primarykeystore] final class InMemoryPrimaryKeyStore(schemaInfo: SchemaI
 
 private object InMemoryPrimaryKeyStore {
   private def buildStorage(schemaInfo: SchemaInfo): Map[Table, mutable.HashSet[Any]] = {
-    val tables: Iterable[Table] = schemaInfo.pksByTableOrdered.keys.filter(_.storePks)
+    val tables: Iterable[Table] = schemaInfo.pksByTableOrdered.keys
     tables.map { t => t -> mutable.HashSet.empty[Any] }.toMap
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/FkTaskPreCheck.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/FkTaskPreCheck.scala
@@ -13,6 +13,6 @@ object FkTaskPreCheck {
    * another class for that case extending ForeignKeyTask called OneToOne[SomethingTask]
   */
   def shouldPrecheck(task: FetchParentTask): Boolean = {
-    task.fk.pointsToPk && task.parentTable.storePks
+    task.fk.pointsToPk
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/SkipPkStore.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/SkipPkStore.scala
@@ -1,9 +1,0 @@
-package trw.dbsubsetter.workflow
-
-
-object SkipPkStore {
-  def process(res: OriginDbResult): PksAdded = {
-    val children = if (res.fetchChildren) res.rows else Vector.empty
-    PksAdded(res.table, res.rows, children, res.viaTableOpt)
-  }
-}

--- a/src/test/scala/e2e/circulardep/CircularDepTestMySql.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestMySql.scala
@@ -6,7 +6,6 @@ class CircularDepTestMySql extends AbstractMysqlEndToEndTest with CircularDepTes
 
   override val programArgs = Array(
     "--schemas", "circular_dep",
-    "--baseQuery", "circular_dep.grandparents ::: id % 6 = 0 ::: includeChildren",
-    "--skipPkStore", "circular_dep.children"
+    "--baseQuery", "circular_dep.grandparents ::: id % 6 = 0 ::: includeChildren"
   )
 }

--- a/src/test/scala/e2e/circulardep/CircularDepTestPostgreSQL.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestPostgreSQL.scala
@@ -6,7 +6,6 @@ class CircularDepTestPostgreSQL extends AbstractPostgresqlEndToEndTest with Circ
 
   override val programArgs = Array(
     "--schemas", "public",
-    "--baseQuery", "public.grandparents ::: id % 6 = 0 ::: includeChildren",
-    "--skipPkStore", "public.children"
+    "--baseQuery", "public.grandparents ::: id % 6 = 0 ::: includeChildren"
   )
 }

--- a/src/test/scala/e2e/circulardep/CircularDepTestSqlServer.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestSqlServer.scala
@@ -6,7 +6,6 @@ class CircularDepTestSqlServer extends AbstractSqlServerEndToEndTest with Circul
 
   override val programArgs = Array(
     "--schemas", "dbo",
-    "--baseQuery", "dbo.grandparents ::: id % 6 = 0 ::: includeChildren",
-    "--skipPkStore", "dbo.children"
+    "--baseQuery", "dbo.grandparents ::: id % 6 = 0 ::: includeChildren"
   )
 }

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestMySql.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestMySql.scala
@@ -6,8 +6,6 @@ class MixedCaseTestMySql extends AbstractMysqlEndToEndTest with MixedCaseTest {
 
   override val programArgs = Array(
     "--schemas", "mIXED_case_DB",
-    "--baseQuery", "mIXED_case_DB.mixed_CASE_table_1 ::: `ID` = 2 ::: includeChildren",
-    "--skipPkStore", "mIXED_case_DB.mixed_CASE_table_1",
-    "--skipPkStore", "mIXED_case_DB.mixed_CASE_table_2"
+    "--baseQuery", "mIXED_case_DB.mixed_CASE_table_1 ::: `ID` = 2 ::: includeChildren"
   )
 }

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestPostgreSQL.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestPostgreSQL.scala
@@ -6,8 +6,6 @@ class MixedCaseTestPostgreSQL extends AbstractPostgresqlEndToEndTest with MixedC
 
   override val programArgs = Array(
     "--schemas", "public",
-    "--baseQuery", "public.mixed_CASE_table_1 ::: \"ID\" = 2 ::: includeChildren",
-    "--skipPkStore", "public.mixed_CASE_table_1",
-    "--skipPkStore", "public.mixed_CASE_table_2"
+    "--baseQuery", "public.mixed_CASE_table_1 ::: \"ID\" = 2 ::: includeChildren"
   )
 }

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestSqlServer.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestSqlServer.scala
@@ -6,8 +6,6 @@ class MixedCaseTestSqlServer extends AbstractSqlServerEndToEndTest with MixedCas
 
   override val programArgs = Array(
     "--schemas", "dbo",
-    "--baseQuery", "dbo.mixed_CASE_table_1 ::: [ID] = 2 ::: includeChildren",
-    "--skipPkStore", "dbo.mixed_CASE_table_1",
-    "--skipPkStore", "dbo.mixed_CASE_table_2"
+    "--baseQuery", "dbo.mixed_CASE_table_1 ::: [ID] = 2 ::: includeChildren"
   )
 }

--- a/src/test/scala/integration/OffHeapTaskQueueTest.scala
+++ b/src/test/scala/integration/OffHeapTaskQueueTest.scala
@@ -67,8 +67,7 @@ private[this] object OffHeapTaskQueueTest {
     new Table(
       schema = "public",
       name = "parent",
-      hasSqlServerAutoIncrement = false,
-      storePks = true
+      hasSqlServerAutoIncrement = false
     )
 
   private[this] val parentPkColumn: Column =
@@ -84,8 +83,7 @@ private[this] object OffHeapTaskQueueTest {
     new Table(
       schema = "public",
       name = "child",
-      hasSqlServerAutoIncrement = false,
-      storePks = true
+      hasSqlServerAutoIncrement = false
     )
 
   private[this] val childFkColumn: Column =

--- a/src/test/scala/load/physics/PhysicsTestPostgreSQL.scala
+++ b/src/test/scala/load/physics/PhysicsTestPostgreSQL.scala
@@ -89,15 +89,10 @@
 //  override protected val programArgs = Array(
 //    "--schemas", "public",
 //    "--baseQuery", "public.scientists ::: id in (2) ::: includeChildren",
-//    //    TODO: fix so that some experiment plans have no scientist. Then use this base query to test auto-skipPkStore calculations
+//    //    TODO: fix so that some experiment plans have no scientist. Then consider using this base query.
 //    //    "--baseQuery", "public.experiment_plans ::: id % 35 = 0 ::: includeChildren",
 //    "--excludeTable", "public.particle_domain",
 //    "--excludeTable", "public.quantum_domain",
 //    "--excludeTable", "public.gravitational_wave_domain",
-//    "--skipPkStore", "public.datum_note_responses",
-//    "--skipPkStore", "public.datum_notes",
-//    "--skipPkStore", "public.gravitational_wave_data",
-//    "--skipPkStore", "public.particle_collider_data",
-//    "--skipPkStore", "public.quantum_data"
 //  )
 //}

--- a/src/test/scala/unit/PkStoreTest.scala
+++ b/src/test/scala/unit/PkStoreTest.scala
@@ -11,8 +11,7 @@ class PkStoreTest extends FunSuite {
       new Table(
         schema = "public",
         name ="users",
-        hasSqlServerAutoIncrement = true,
-        storePks = true
+        hasSqlServerAutoIncrement = true
       )
 
     val pkCol: Column =

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -12,8 +12,7 @@ class PkStoreWorkflowTest extends FunSuite {
       new Table(
         schema = "public",
         name = "users",
-        hasSqlServerAutoIncrement = true,
-        storePks = true
+        hasSqlServerAutoIncrement = true
       )
 
     val pkCol: Column =
@@ -77,8 +76,7 @@ class PkStoreWorkflowTest extends FunSuite {
       new Table(
         schema = "public",
         name = "users",
-        hasSqlServerAutoIncrement = true,
-        storePks = true
+        hasSqlServerAutoIncrement = true
       )
 
     val primaryKeyColumn: Column =


### PR DESCRIPTION
Remove the poorly documented (and very-hard-to-use-correctly) `skipPkStore` option. Removing it simplifies our logic.

This option was an experiment for reducing memory usage of the in memory primary key store. However, it was never clear that the memory usage of the primary key store was actually the biggest problem, compared to the memory usage of the pre-target buffer.

This option was also an experiment in improving performance. However, it was also never clear that the primary key store was the performance bottleneck.