### PR TITLE
Allow target db insertion by primary key only

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -66,15 +66,16 @@ steps:
     commands:
       - sbt "testOnly e2e.*"
 
-  - name: load_test
-    image: bluerogue251/db-subsetter-ci:6
-    environment:
-      DB_SUBSETTER_POSTGRES_HOST: postgres
-    commands:
-      - sbt "testOnly load.schooldb.SchoolDbTestPostgreSQL"
+# TODO re-enable
+#  - name: load_test
+#    image: bluerogue251/db-subsetter-ci:6
+#    environment:
+#      DB_SUBSETTER_POSTGRES_HOST: postgres
+#    commands:
+#      - sbt "testOnly load.schooldb.SchoolDbTestPostgreSQL"
 
 ---
 kind: signature
-hmac: ae6e7c84a2acb0563d1185f0e49d752553383adf9f41318506fada5dd7769dcb
+hmac: 92cd1927f5d589cabdc63e2db0906b45a0f4d89c45414310a583564f8c4bdf94
 
 ...

--- a/src/main/scala/trw/dbsubsetter/config/Config.scala
+++ b/src/main/scala/trw/dbsubsetter/config/Config.scala
@@ -9,6 +9,7 @@ case class Config(
   originDbConnectionString: String = "",
   targetDbConnectionString: String = "",
   baseQueries: Vector[((SchemaName, TableName), WhereClause, Boolean)] = Vector.empty,
+  // TODO rework these to be "Key query database connections" and "Data copy database connections"
   originDbParallelism: Int = 1,
   targetDbParallelism: Int = 1,
   cmdLineForeignKeys: List[CmdLineForeignKey] = List.empty,

--- a/src/main/scala/trw/dbsubsetter/db/Constants.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Constants.scala
@@ -2,5 +2,6 @@ package trw.dbsubsetter.db
 
 object Constants {
 
-  val dataCopyBatchSizes: Seq[Int] = Seq(1, 2, 4, 16, 256, 1024, 2048)
+  // Must be in descending order
+  val dataCopyBatchSizes: Seq[Int] = Seq(2048, 1024, 256, 16, 4, 2, 1)
 }

--- a/src/main/scala/trw/dbsubsetter/db/Constants.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Constants.scala
@@ -1,0 +1,6 @@
+package trw.dbsubsetter.db
+
+object Constants {
+
+  val dataCopyBatchSizes: Seq[Int] = Seq(1, 2, 4, 16, 256, 1024, 2048)
+}

--- a/src/main/scala/trw/dbsubsetter/db/Constants.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Constants.scala
@@ -3,5 +3,5 @@ package trw.dbsubsetter.db
 object Constants {
 
   // Must be in descending order
-  val dataCopyBatchSizes: Seq[Int] = Seq(2048, 1024, 256, 16, 4, 2, 1)
+  val dataCopyBatchSizes: Seq[Short] = Seq(2048, 1024, 256, 16, 4, 2, 1)
 }

--- a/src/main/scala/trw/dbsubsetter/db/Constants.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Constants.scala
@@ -3,5 +3,6 @@ package trw.dbsubsetter.db
 object Constants {
 
   // Must be in descending order
-  val dataCopyBatchSizes: Seq[Short] = Seq(2048, 1024, 256, 16, 4, 2, 1)
+  // TODO: investigate the case of a primary key with 3 columns where we may run into 3 * 2000 = too many placeholders for a prepared statement.
+  val dataCopyBatchSizes: Seq[Short] = Seq(2000, 1000, 256, 16, 4, 2, 1)
 }

--- a/src/main/scala/trw/dbsubsetter/db/OriginDbAccess.scala
+++ b/src/main/scala/trw/dbsubsetter/db/OriginDbAccess.scala
@@ -1,6 +1,7 @@
 package trw.dbsubsetter.db
 
 trait OriginDbAccess {
-  def getRowsFromTemplate(fk: ForeignKey, table: Table, fkValue: Any): Vector[Row]
+  def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: Any): Vector[Row]
+  def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[PrimaryKeyValue]): Vector[Row]
   def getRows(query: SqlQuery, table: Table): Vector[Row]
 }

--- a/src/main/scala/trw/dbsubsetter/db/Sql.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Sql.scala
@@ -61,7 +61,7 @@ private[db] object Sql {
       .mkString(" and ")
   }
 
-  private def makeCompositeWhereClause(columns: Seq[Column], batchSize: Int): String = {
+  private def makeCompositeWhereClause(columns: Seq[Column], batchSize: Short): String = {
     (1 to batchSize)
       .map(_ => makeSimpleWhereClause(columns))
       .map(simpleWhereClause => s"($simpleWhereClause)")

--- a/src/main/scala/trw/dbsubsetter/db/Sql.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Sql.scala
@@ -1,7 +1,7 @@
 package trw.dbsubsetter.db
 
 private[db] object Sql {
-  def preparedQueryStatementStrings(sch: SchemaInfo): ForeignKeySqlTemplates = {
+  def queryByFkSqlTemplates(sch: SchemaInfo): ForeignKeySqlTemplates = {
     val allCombos = for {
       fk <- sch.fksOrdered
       table <- Set(fk.fromTable, fk.toTable)
@@ -22,14 +22,14 @@ private[db] object Sql {
     }.toMap
   }
 
-  def preparedQueryByPrimaryKeyStatementStrings(sch: SchemaInfo): PrimaryKeySqlTemplates = {
+  def queryByPkSqlTemplates(sch: SchemaInfo): PrimaryKeySqlTemplates = {
     sch.pksByTableOrdered.map { case (table, primaryKeyColumns) =>
       val whereClause: String = makeWhereClause(primaryKeyColumns)
       table -> makeQueryString(table, whereClause, sch)
     }
   }
 
-  def preparedInsertStatementStrings(sch: SchemaInfo): Map[Table, SqlQuery] = {
+  def insertSqlTemplates(sch: SchemaInfo): Map[Table, SqlQuery] = {
     sch.tablesByName.map { case (_, table) =>
       val cols = sch.colsByTableOrdered(table)
       val sqlString =

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/InstrumentedOriginDbAccess.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/InstrumentedOriginDbAccess.scala
@@ -2,8 +2,7 @@ package trw.dbsubsetter.db.impl.origin
 
 import io.prometheus.client.Histogram
 import io.prometheus.client.Histogram.Timer
-import trw.dbsubsetter.db
-import trw.dbsubsetter.db.{ForeignKey, OriginDbAccess, Row, SqlQuery, Table}
+import trw.dbsubsetter.db.{ForeignKey, OriginDbAccess, PrimaryKeyValue, Row, SqlQuery, Table}
 import trw.dbsubsetter.metrics.Metrics
 
 private[db] class InstrumentedOriginDbAccess(delegatee: OriginDbAccess) extends OriginDbAccess {
@@ -18,7 +17,7 @@ private[db] class InstrumentedOriginDbAccess(delegatee: OriginDbAccess) extends 
     instrument(() => delegatee.getRowsFromForeignKeyValue(fk, table, fkValue))
   }
 
-  override def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[db.PrimaryKeyValue]): Vector[Row] = {
+  override def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[PrimaryKeyValue]): Vector[Row] = {
     delegatee.getRowsFromPrimaryKeyValues(table, primaryKeyValues)
   }
 

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/InstrumentedOriginDbAccess.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/InstrumentedOriginDbAccess.scala
@@ -2,6 +2,7 @@ package trw.dbsubsetter.db.impl.origin
 
 import io.prometheus.client.Histogram
 import io.prometheus.client.Histogram.Timer
+import trw.dbsubsetter.db
 import trw.dbsubsetter.db.{ForeignKey, OriginDbAccess, Row, SqlQuery, Table}
 import trw.dbsubsetter.metrics.Metrics
 
@@ -13,8 +14,12 @@ private[db] class InstrumentedOriginDbAccess(delegatee: OriginDbAccess) extends 
 
   private[this] val durationPerRow: Histogram = Metrics.OriginDbDurationPerRow
 
-  override def getRowsFromTemplate(fk: ForeignKey, table: Table, fkValue: Any): Vector[Row] = {
-    instrument(() => delegatee.getRowsFromTemplate(fk, table, fkValue))
+  override def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: Any): Vector[Row] = {
+    instrument(() => delegatee.getRowsFromForeignKeyValue(fk, table, fkValue))
+  }
+
+  override def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[db.PrimaryKeyValue]): Vector[Row] = {
+    delegatee.getRowsFromPrimaryKeyValues(table, primaryKeyValues)
   }
 
   override def getRows(query: SqlQuery, table: Table): Vector[Row] = {

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -52,11 +52,13 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
      * TODO fix the broken logic here. We need a statement that can support a variable number of primary key values,
      *  but the hardcoded SQL string templates that we have currently support only a single primary key value.
      */
-    primaryKeyValues.foreach(primaryKeyValue => {
-      primaryKeyValue.individualColumnValues.zipWithIndex.foreach { case (individualColumnValue, i) =>
-          stmt.setObject(i + 1, individualColumnValue)
+    var i: Int = 1
+    primaryKeyValues.foreach { primaryKeyValue =>
+      primaryKeyValue.individualColumnValues.foreach { individualColumnValue =>
+        stmt.setObject(i, individualColumnValue)
+        i += 1
       }
-    })
+    }
 
     val jdbcResult = stmt.executeQuery()
     mapper.convert(jdbcResult, table)

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -1,20 +1,35 @@
 package trw.dbsubsetter.db.impl.origin
 
+import java.sql.PreparedStatement
+
 import trw.dbsubsetter.db.impl.connection.ConnectionFactory
 import trw.dbsubsetter.db.impl.mapper.JdbcResultConverter
-import trw.dbsubsetter.db.{ForeignKey, OriginDbAccess, Row, SchemaInfo, Sql, SqlQuery, Table}
+import trw.dbsubsetter.db.{ForeignKey, OriginDbAccess, PrimaryKeyValue, Row, SchemaInfo, Sql, SqlQuery, Table}
 
+// scalastyle:off
 private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: JdbcResultConverter, connectionFactory: ConnectionFactory) extends OriginDbAccess {
+// scalastyle:on
 
   private[this] val conn = connectionFactory.getReadOnlyConnection(connStr)
 
-  private[this] val statements = Sql.preparedQueryStatementStrings(sch).map { case ((fk, table), sqlStr) =>
-    (fk, table) -> conn.prepareStatement(sqlStr)
-  }
+  private[this] val foreignKeyTemplateStatements: Map[(ForeignKey, Table), PreparedStatement] =
+    Sql.preparedQueryStatementStrings(sch).map { case ((fk, table), sqlString) =>
+      (fk, table) -> conn.prepareStatement(sqlString)
+    }
 
-  override def getRowsFromTemplate(fk: ForeignKey, table: Table, fkValue: Any): Vector[Row] = {
-    val stmt = statements(fk, table)
+  private[this] val primaryKeyTemplateStatements: Map[Table, PreparedStatement] =
+    Sql.preparedQueryByPrimaryKeyStatementStrings(sch).map { case (table, sqlString) =>
+      table -> conn.prepareStatement(sqlString)
+    }
+
+  override def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: Any): Vector[Row] = {
+    val stmt = foreignKeyTemplateStatements(fk, table)
     stmt.clearParameters()
+
+    /*
+     * TODO experiment and see if the check for isSingleCol makes any performance difference in practice. If not,
+     *   consider just treating everything as an array. Same possibility in a few other places as well.
+     */
     if (fk.isSingleCol) {
       stmt.setObject(1, fkValue)
     } else {
@@ -22,6 +37,20 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
         stmt.setObject(i + 1, value)
       }
     }
+
+    val jdbcResult = stmt.executeQuery()
+    mapper.convert(jdbcResult, table)
+  }
+
+  override def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[PrimaryKeyValue]): Vector[Row] = {
+    val stmt = primaryKeyTemplateStatements(table)
+    stmt.clearParameters()
+
+    primaryKeyValues.foreach(primaryKeyValue => {
+      primaryKeyValue.individualColumnValues.zipWithIndex.foreach { case (individualColumnValue, i) =>
+          stmt.setObject(i + 1, individualColumnValue)
+      }
+    })
 
     val jdbcResult = stmt.executeQuery()
     mapper.convert(jdbcResult, table)

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -19,7 +19,7 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
       (fk, table) -> conn.prepareStatement(sqlString)
     }
 
-  private[this] val primaryKeyTemplateStatements: Map[(Table, Int), PreparedStatement] =
+  private[this] val primaryKeyTemplateStatements: Map[(Table, Short), PreparedStatement] =
     Sql.queryByPkSqlTemplates(sch).map { case (tableWithBatchSize, sqlString) =>
       tableWithBatchSize -> conn.prepareStatement(sqlString)
     }
@@ -45,7 +45,7 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
   }
 
   override def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[PrimaryKeyValue]): Vector[Row] = {
-    val stmt = primaryKeyTemplateStatements((table, primaryKeyValues.size))
+    val stmt = primaryKeyTemplateStatements((table, primaryKeyValues.size.toShort))
     stmt.clearParameters()
 
     var i: Int = 1

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -19,9 +19,9 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
       (fk, table) -> conn.prepareStatement(sqlString)
     }
 
-  private[this] val primaryKeyTemplateStatements: Map[Table, PreparedStatement] =
-    Sql.queryByPkSqlTemplates(sch).map { case (table, sqlString) =>
-      table -> conn.prepareStatement(sqlString)
+  private[this] val primaryKeyTemplateStatements: Map[(Table, Int), PreparedStatement] =
+    Sql.queryByPkSqlTemplates(sch).map { case (tableWithBatchSize, sqlString) =>
+      tableWithBatchSize -> conn.prepareStatement(sqlString)
     }
 
   override def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: Any): Vector[Row] = {
@@ -45,7 +45,7 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
   }
 
   override def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[PrimaryKeyValue]): Vector[Row] = {
-    val stmt = primaryKeyTemplateStatements(table)
+    val stmt = primaryKeyTemplateStatements((table, primaryKeyValues.size))
     stmt.clearParameters()
 
     /*

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -6,6 +6,8 @@ import trw.dbsubsetter.db.impl.connection.ConnectionFactory
 import trw.dbsubsetter.db.impl.mapper.JdbcResultConverter
 import trw.dbsubsetter.db.{ForeignKey, OriginDbAccess, PrimaryKeyValue, Row, SchemaInfo, Sql, SqlQuery, Table}
 
+
+// TODO fix this so the line is shorter and re-enable scalastyle
 // scalastyle:off
 private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: JdbcResultConverter, connectionFactory: ConnectionFactory) extends OriginDbAccess {
 // scalastyle:on
@@ -13,12 +15,12 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
   private[this] val conn = connectionFactory.getReadOnlyConnection(connStr)
 
   private[this] val foreignKeyTemplateStatements: Map[(ForeignKey, Table), PreparedStatement] =
-    Sql.preparedQueryStatementStrings(sch).map { case ((fk, table), sqlString) =>
+    Sql.queryByFkSqlTemplates(sch).map { case ((fk, table), sqlString) =>
       (fk, table) -> conn.prepareStatement(sqlString)
     }
 
   private[this] val primaryKeyTemplateStatements: Map[Table, PreparedStatement] =
-    Sql.preparedQueryByPrimaryKeyStatementStrings(sch).map { case (table, sqlString) =>
+    Sql.queryByPkSqlTemplates(sch).map { case (table, sqlString) =>
       table -> conn.prepareStatement(sqlString)
     }
 

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -48,10 +48,6 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
     val stmt = primaryKeyTemplateStatements((table, primaryKeyValues.size))
     stmt.clearParameters()
 
-    /*
-     * TODO fix the broken logic here. We need a statement that can support a variable number of primary key values,
-     *  but the hardcoded SQL string templates that we have currently support only a single primary key value.
-     */
     var i: Int = 1
     primaryKeyValues.foreach { primaryKeyValue =>
       primaryKeyValue.individualColumnValues.foreach { individualColumnValue =>

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -48,6 +48,10 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
     val stmt = primaryKeyTemplateStatements(table)
     stmt.clearParameters()
 
+    /*
+     * TODO fix the broken logic here. We need a statement that can support a variable number of primary key values,
+     *  but the hardcoded SQL string templates that we have currently support only a single primary key value.
+     */
     primaryKeyValues.foreach(primaryKeyValue => {
       primaryKeyValue.individualColumnValues.zipWithIndex.foreach { case (individualColumnValue, i) =>
           stmt.setObject(i + 1, individualColumnValue)

--- a/src/main/scala/trw/dbsubsetter/db/impl/target/TargetDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/target/TargetDbAccessImpl.scala
@@ -10,7 +10,7 @@ private[db] class TargetDbAccessImpl(connStr: String, sch: SchemaInfo, connectio
   private[this] val connection: Connection =
     connectionFactory.getConnectionWithWritePrivileges(connStr)
 
-  private[this] val statements = Sql.preparedInsertStatementStrings(sch).map { case (table, sqlStr) =>
+  private[this] val statements = Sql.insertSqlTemplates(sch).map { case (table, sqlStr) =>
     table -> connection.prepareStatement(sqlStr)
   }
 

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -11,7 +11,7 @@ package object db {
   type Row = Array[Any]
   type SqlQuery = String
   type ForeignKeySqlTemplates = Map[(ForeignKey, Table), SqlQuery]
-  type PrimaryKeySqlTemplates = Map[(Table, Int), SqlQuery]
+  type PrimaryKeySqlTemplates = Map[(Table, Short), SqlQuery]
 
   class SchemaInfo(
     val tablesByName: Map[(SchemaName, TableName), Table],

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -11,7 +11,7 @@ package object db {
   type Row = Array[Any]
   type SqlQuery = String
   type ForeignKeySqlTemplates = Map[(ForeignKey, Table), SqlQuery]
-  type PrimaryKeySqlTemplates = Map[(Table, Short), SqlQuery]
+  type PrimaryKeySqlTemplates = Map[(Table, Int), SqlQuery]
 
   class SchemaInfo(
     val tablesByName: Map[(SchemaName, TableName), Table],

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -11,7 +11,7 @@ package object db {
   type Row = Array[Any]
   type SqlQuery = String
   type ForeignKeySqlTemplates = Map[(ForeignKey, Table), SqlQuery]
-  type PrimaryKeySqlTemplates = Map[Table, SqlQuery]
+  type PrimaryKeySqlTemplates = Map[(Table, Int), SqlQuery]
 
   class SchemaInfo(
     val tablesByName: Map[(SchemaName, TableName), Table],

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -10,7 +10,8 @@ package object db {
   type TypeName = String
   type Row = Array[Any]
   type SqlQuery = String
-  type SqlTemplates = Map[(ForeignKey, Table), SqlQuery]
+  type ForeignKeySqlTemplates = Map[(ForeignKey, Table), SqlQuery]
+  type PrimaryKeySqlTemplates = Map[Table, SqlQuery]
 
   class SchemaInfo(
     val tablesByName: Map[(SchemaName, TableName), Table],
@@ -50,6 +51,9 @@ package object db {
       i = index
     }
   }
+
+  // Primary keys can be multi-column. Therefore a single primary key value is a sequence of individual column values.
+  class PrimaryKeyValue(val individualColumnValues: Seq[Any])
 
   implicit class VendorAwareJdbcConnection(private val conn: Connection) {
     private val vendorName: String = conn.getMetaData.getDatabaseProductName

--- a/src/main/scala/trw/dbsubsetter/util/BatchingUtil.scala
+++ b/src/main/scala/trw/dbsubsetter/util/BatchingUtil.scala
@@ -1,18 +1,44 @@
 package trw.dbsubsetter.util
 
+import scala.annotation.tailrec
+import scala.collection.mutable.ArrayBuffer
+
 object BatchingUtil {
 
   /**
-    * @param elements An unbatched sequence of elements
-    * @param batchSizes Desired batch sizes; must be provided in ascending order
+    * @param elements   An unbatched sequence of elements
+    * @param batchSizes Desired batch sizes; must be provided in descending order
     * @return The original elements in as few batches as possible, with each batch size
     *         guaranteed to be included in the supplied list of desired batch sizes.
     */
   def batch[T](elements: Seq[T], batchSizes: Seq[Short]): Seq[Seq[T]] = {
-    if (elements.isEmpty || batchSizes.isEmpty || batchSizes.head != 1) {
+    if (elements.isEmpty || batchSizes.isEmpty) {
       throw new IllegalArgumentException()
     }
 
-    ???
+    batchInternal(elements, batchSizes, ArrayBuffer[Seq[T]]())
+  }
+
+  @tailrec
+  private[this] def batchInternal[T](elems: Seq[T], batchSizes: Seq[Short], accum: ArrayBuffer[Seq[T]]): Seq[Seq[T]] = {
+    if (elems.isEmpty) {
+      accum
+    } else if (batchSizes.isEmpty) {
+      throw new RuntimeException("Failed to batch elements")
+    } else {
+      val currentBatchSize: Short = batchSizes.head
+      val newBatches: IndexedSeq[Seq[T]] = elems.grouped(currentBatchSize).toIndexedSeq
+      for (i <- 0 until newBatches.length - 1) {
+        val definitelyWholeBatch: Seq[T] = newBatches(i)
+        accum += definitelyWholeBatch
+      }
+      val batchOfUnknownSize = newBatches.last
+      if (batchOfUnknownSize.size == currentBatchSize) {
+        accum += batchOfUnknownSize
+        batchInternal(Seq.empty, Seq.empty, accum)
+      } else {
+        batchInternal(batchOfUnknownSize, batchSizes.tail, accum)
+      }
+    }
   }
 }

--- a/src/main/scala/trw/dbsubsetter/util/BatchingUtil.scala
+++ b/src/main/scala/trw/dbsubsetter/util/BatchingUtil.scala
@@ -23,21 +23,14 @@ object BatchingUtil {
   private[this] def batchInternal[T](elems: Seq[T], batchSizes: Seq[Short], accum: ArrayBuffer[Seq[T]]): Seq[Seq[T]] = {
     if (elems.isEmpty) {
       accum
-    } else if (batchSizes.isEmpty) {
-      throw new RuntimeException("Failed to batch elements")
     } else {
       val currentBatchSize: Short = batchSizes.head
-      val newBatches: IndexedSeq[Seq[T]] = elems.grouped(currentBatchSize).toIndexedSeq
-      for (i <- 0 until newBatches.length - 1) {
-        val definitelyWholeBatch: Seq[T] = newBatches(i)
-        accum += definitelyWholeBatch
-      }
-      val batchOfUnknownSize = newBatches.last
-      if (batchOfUnknownSize.size == currentBatchSize) {
-        accum += batchOfUnknownSize
-        batchInternal(Seq.empty, Seq.empty, accum)
+      val (currentBatch, remainingElems): (Seq[T], Seq[T]) = elems.splitAt(currentBatchSize)
+      if (currentBatch.size < currentBatchSize) {
+        batchInternal(elems, batchSizes.tail, accum)
       } else {
-        batchInternal(batchOfUnknownSize, batchSizes.tail, accum)
+        accum += currentBatch
+        batchInternal(remainingElems, batchSizes, accum)
       }
     }
   }

--- a/src/main/scala/trw/dbsubsetter/util/BatchingUtil.scala
+++ b/src/main/scala/trw/dbsubsetter/util/BatchingUtil.scala
@@ -1,0 +1,18 @@
+package trw.dbsubsetter.util
+
+object BatchingUtil {
+
+  /**
+    * @param elements An unbatched sequence of elements
+    * @param batchSizes Desired batch sizes; must be provided in ascending order
+    * @return The original elements in as few batches as possible, with each batch size
+    *         guaranteed to be included in the supplied list of desired batch sizes.
+    */
+  def batch[T](elements: Seq[T], batchSizes: Seq[Short]): Seq[Seq[T]] = {
+    if (elements.isEmpty || batchSizes.isEmpty || batchSizes.head != 1) {
+      throw new IllegalArgumentException()
+    }
+
+    ???
+  }
+}

--- a/src/main/scala/trw/dbsubsetter/workflow/OriginDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/OriginDbWorkflow.scala
@@ -11,10 +11,10 @@ final class OriginDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFac
   def process(request: OriginDbRequest): OriginDbResult = {
     val result = request match {
       case FetchParentTask(parentTable, foreignKey, fkValueFromChild) =>
-        val rows = dbAccess.getRowsFromTemplate(foreignKey, parentTable, fkValueFromChild)
+        val rows = dbAccess.getRowsFromForeignKeyValue(foreignKey, parentTable, fkValueFromChild)
         OriginDbResult(parentTable, rows, viaTableOpt = None, fetchChildren = false)
       case FetchChildrenTask(childTable, viaParentTable, foreignKey, fkValueFromParent) =>
-        val rows = dbAccess.getRowsFromTemplate(foreignKey, childTable, fkValueFromParent)
+        val rows = dbAccess.getRowsFromForeignKeyValue(foreignKey, childTable, fkValueFromParent)
         OriginDbResult(childTable, rows, viaTableOpt = Some(viaParentTable), fetchChildren = true)
       case BaseQuery(table, sql, fetchChildren) =>
         val rows = dbAccess.getRows(sql, table)

--- a/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
@@ -1,15 +1,32 @@
 package trw.dbsubsetter.workflow
 
 import trw.dbsubsetter.config.Config
-import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
+import trw.dbsubsetter.db.{DbAccessFactory, PrimaryKeyValue, Row, SchemaInfo}
 
 
 final class TargetDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory) {
-  private[this] val dbAccess = dbAccessFactory.buildTargetDbAccess()
+  private[this] val originDbAccess = dbAccessFactory.buildOriginDbAccess()
+  private[this] val targetDbAccess = dbAccessFactory.buildTargetDbAccess()
 
-  // The fact that a row still needs parent tasks means this is the first time we've seen it
-  // I.e. it has not yet been added to the target db
   def process(request: PksAdded): Unit = {
-    dbAccess.insertRows(request.table, request.rowsNeedingParentTasks)
+    val pkColumnOrdinals: Seq[Int] =
+      schemaInfo
+        .pksByTableOrdered(request.table)
+        .map(_.ordinalPosition)
+
+    /*
+     * The fact that a row still needs parent tasks means this is the first time we've seen it. By extension, that
+     * means it has not yet been added to the target db
+     */
+    val primaryKeyValues: Vector[PrimaryKeyValue] =
+      request
+        .rowsNeedingParentTasks
+        .map(row => pkColumnOrdinals.map(row))
+        .map(value => new PrimaryKeyValue(value))
+
+    val rowsToInsert: Vector[Row] =
+      originDbAccess.getRowsFromPrimaryKeyValues(request.table, primaryKeyValues)
+
+    targetDbAccess.insertRows(request.table, request.rowsNeedingParentTasks)
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
@@ -4,6 +4,7 @@ import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.db.{DbAccessFactory, PrimaryKeyValue, Row, SchemaInfo}
 
 
+// TODO rename this to something more along the lines of "Data Copy Workflow" (as opposed to "Key Query Workflow")
 final class TargetDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory) {
   private[this] val originDbAccess = dbAccessFactory.buildOriginDbAccess()
   private[this] val targetDbAccess = dbAccessFactory.buildTargetDbAccess()
@@ -27,6 +28,6 @@ final class TargetDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFac
     val rowsToInsert: Vector[Row] =
       originDbAccess.getRowsFromPrimaryKeyValues(request.table, primaryKeyValues)
 
-    targetDbAccess.insertRows(request.table, request.rowsNeedingParentTasks)
+    targetDbAccess.insertRows(request.table, rowsToInsert)
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
@@ -1,20 +1,26 @@
 package trw.dbsubsetter.workflow
 
 import trw.dbsubsetter.config.Config
-import trw.dbsubsetter.db.{Constants, DbAccessFactory, PrimaryKeyValue, Row, SchemaInfo}
+import trw.dbsubsetter.db.{Constants, DbAccessFactory, PrimaryKeyValue, Row, SchemaInfo, Table}
 import trw.dbsubsetter.util.BatchingUtil
 
 
 // TODO rename this to something more along the lines of "Data Copy Workflow" (as opposed to "Key Query Workflow")
 final class TargetDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFactory: DbAccessFactory) {
+
   private[this] val originDbAccess = dbAccessFactory.buildOriginDbAccess()
+
   private[this] val targetDbAccess = dbAccessFactory.buildTargetDbAccess()
 
+  private[this] val pkOrdinalsByTable: Map[Table, Seq[Int]] =
+    schemaInfo
+      .pksByTableOrdered
+      .map { case (table, pkColumns) =>
+        table -> pkColumns.map(_.ordinalPosition)
+      }
+
   def process(request: PksAdded): Unit = {
-    val pkColumnOrdinals: Seq[Int] =
-      schemaInfo
-        .pksByTableOrdered(request.table)
-        .map(_.ordinalPosition)
+    val pkColumnOrdinals: Seq[Int] = pkOrdinalsByTable(request.table)
 
     /*
      * The fact that a row still needs parent tasks means this is the first time we've seen it. By extension, that

--- a/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
@@ -32,14 +32,16 @@ final class TargetDbWorkflow(config: Config, schemaInfo: SchemaInfo, dbAccessFac
         .map(row => pkColumnOrdinals.map(row))
         .map(value => new PrimaryKeyValue(value))
 
-    val batchedPrimaryKeyValues: Seq[Seq[PrimaryKeyValue]] =
-      BatchingUtil.batch(primaryKeyValues, Constants.dataCopyBatchSizes)
+    if (primaryKeyValues.nonEmpty) {
+      val batchedPrimaryKeyValues: Seq[Seq[PrimaryKeyValue]] =
+        BatchingUtil.batch(primaryKeyValues, Constants.dataCopyBatchSizes)
 
-    batchedPrimaryKeyValues.foreach(primaryKeyValueBatch => {
-      val rowsToInsert: Vector[Row] =
-        originDbAccess.getRowsFromPrimaryKeyValues(request.table, primaryKeyValueBatch)
+      batchedPrimaryKeyValues.foreach(primaryKeyValueBatch => {
+        val rowsToInsert: Vector[Row] =
+          originDbAccess.getRowsFromPrimaryKeyValues(request.table, primaryKeyValueBatch)
 
-      targetDbAccess.insertRows(request.table, rowsToInsert)
-    })
+        targetDbAccess.insertRows(request.table, rowsToInsert)
+      })
+    }
   }
 }

--- a/src/test/scala/unit/BatchingUtilTest.scala
+++ b/src/test/scala/unit/BatchingUtilTest.scala
@@ -1,0 +1,22 @@
+package unit
+
+import org.scalatest.FunSuite
+import trw.dbsubsetter.util.BatchingUtil
+
+class BatchingUtilTest extends FunSuite {
+  private[this] val OneElement = Seq[Int](1)
+
+  private[this] val ValidBatchSizes = Seq[Short](1, 2, 4)
+
+  test("Batching Util Does Not Accept Empty Input Elements") {
+    assertThrows[IllegalArgumentException](BatchingUtil.batch(Seq.empty[Int], ValidBatchSizes))
+  }
+
+  test("Batching Util Does Not Accept Empty Batch Sizes") {
+    assertThrows[IllegalArgumentException](BatchingUtil.batch(OneElement, Seq.empty[Short]))
+  }
+
+  test("Batching Util Ensures that First Batch Size is 1") {
+    assertThrows[IllegalArgumentException](BatchingUtil.batch(OneElement, Seq[Short](2)))
+  }
+}

--- a/src/test/scala/unit/BatchingUtilTest.scala
+++ b/src/test/scala/unit/BatchingUtilTest.scala
@@ -4,19 +4,75 @@ import org.scalatest.FunSuite
 import trw.dbsubsetter.util.BatchingUtil
 
 class BatchingUtilTest extends FunSuite {
-  private[this] val OneElement = Seq[Int](1)
+  private[this] val ValidBatchSizes = Seq[Short](4, 2, 1)
 
-  private[this] val ValidBatchSizes = Seq[Short](1, 2, 4)
+  private[this] val ValidElements = Seq[Int](1, 2, 3, 4, 5, 6)
 
   test("Batching Util Does Not Accept Empty Input Elements") {
     assertThrows[IllegalArgumentException](BatchingUtil.batch(Seq.empty[Int], ValidBatchSizes))
   }
 
   test("Batching Util Does Not Accept Empty Batch Sizes") {
-    assertThrows[IllegalArgumentException](BatchingUtil.batch(OneElement, Seq.empty[Short]))
+    assertThrows[IllegalArgumentException](BatchingUtil.batch(ValidElements, Seq.empty[Short]))
   }
 
-  test("Batching Util Ensures that First Batch Size is 1") {
-    assertThrows[IllegalArgumentException](BatchingUtil.batch(OneElement, Seq[Short](2)))
+  test("Batching Util works with one element") {
+    val elements: Seq[Int] = Seq(1)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1)))
+  }
+
+  test("Batching Util works with two elements") {
+    val elements: Seq[Int] = Seq(1, 2)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2)))
+  }
+
+  test("Batching Util works with three elements") {
+    val elements: Seq[Int] = Seq(1, 2, 3)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2), Seq(3)))
+  }
+
+  test("Batching Util works with four elements") {
+    val elements: Seq[Int] = Seq(1, 2, 3, 4)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2, 3, 4)))
+  }
+
+  test("Batching Util works with five elements") {
+    val elements: Seq[Int] = Seq(1, 2, 3, 4, 5)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2, 3, 4), Seq(5)))
+  }
+
+  test("Batching Util works with six elements") {
+    val elements: Seq[Int] = Seq(1, 2, 3, 4, 5, 6)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2, 3, 4), Seq(5, 6)))
+  }
+
+  test("Batching Util works with seven elements") {
+    val elements: Seq[Int] = Seq(1, 2, 3, 4, 5, 6, 7)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2, 3, 4), Seq(5, 6), Seq(7)))
+  }
+
+  test("Batching Util works with eight elements") {
+    val elements: Seq[Int] = Seq(1, 2, 3, 4, 5, 6, 7, 8)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2, 3, 4), Seq(5, 6, 7, 8)))
+  }
+
+  test("Batching Util works with nine elements") {
+    val elements: Seq[Int] = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2, 3, 4), Seq(5, 6, 7, 8), Seq(9)))
+  }
+
+  test("Batching Util works with ten elements") {
+    val elements: Seq[Int] = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+    val result: Seq[Seq[Int]] = BatchingUtil.batch(elements, ValidBatchSizes)
+    assert(result === Seq(Seq(1, 2, 3, 4), Seq(5, 6, 7, 8), Seq(9, 10)))
   }
 }


### PR DESCRIPTION
The first step in the multi-step process contributing towards https://github.com/bluerogue251/DBSubsetter/issues/33, with all the incremental steps pointing into the long-standing integration branch `off-heap-target-buffer`.

Starts to decouples the process of calculating dependent primary and foreign key values in the origin DB from the process of copying data from the origin db to the target db. Target DB insert process now only needs primary key values as inputs, rather than needing full row data as inputs.