### PR TITLE
Chronicle queue refactors

### DIFF
--- a/src/main/scala/trw/dbsubsetter/db/ColumnTypes.scala
+++ b/src/main/scala/trw/dbsubsetter/db/ColumnTypes.scala
@@ -1,0 +1,34 @@
+package trw.dbsubsetter.db
+
+import java.sql.JDBCType
+
+import trw.dbsubsetter.db.DbVendor.{MicrosoftSQLServer, MySQL, PostgreSQL}
+
+
+object ColumnTypes {
+  sealed trait ColumnType
+
+  case object Short extends ColumnType
+  case object Int extends ColumnType
+  case object Long extends ColumnType
+  case object BigInteger extends ColumnType
+  case object String extends ColumnType
+  case object ByteArray extends ColumnType
+  case object Uuid extends ColumnType
+  case class Unknown(description: String) extends ColumnType
+
+  def fromRawInfo(jdbcType: JDBCType, typeName: TypeName, vendor: DbVendor): ColumnType = {
+    (jdbcType, typeName, vendor) match {
+      case (JDBCType.TINYINT | JDBCType.SMALLINT, _, MicrosoftSQLServer) => ColumnTypes.Short
+      case (JDBCType.INTEGER, "INT UNSIGNED", MySQL) => ColumnTypes.Long
+      case (JDBCType.TINYINT | JDBCType.SMALLINT | JDBCType.INTEGER, _, _) => ColumnTypes.Int
+      case (JDBCType.BIGINT, "BIGINT UNSIGNED", MySQL) => ColumnTypes.BigInteger
+      case (JDBCType.BIGINT, _, _) => ColumnTypes.Long
+      case (JDBCType.CHAR | JDBCType.VARCHAR | JDBCType.LONGVARCHAR | JDBCType.NCHAR, _, _) => ColumnTypes.String
+      case (JDBCType.BINARY | JDBCType.VARBINARY | JDBCType.LONGVARBINARY, _, _) => ColumnTypes.ByteArray
+      case (_, "uuid", PostgreSQL) => ColumnTypes.Uuid
+      case _ => ColumnTypes.Unknown(s"JDBC Type: $jdbcType, TypeName: $typeName")
+    }
+  }
+}
+

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -95,8 +95,7 @@ object SchemaInfoRetrieval {
       pksByTableOrdered,
       foreignKeysOrdered,
       fksFromTable,
-      fksToTable,
-      dbVendor
+      fksToTable
     )
   }
 }

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -3,7 +3,9 @@ package trw.dbsubsetter.db
 import java.util.NoSuchElementException
 
 import trw.dbsubsetter.config.Config
+import trw.dbsubsetter.db.ColumnTypes.ColumnType
 
+// scalastyle:off
 object SchemaInfoRetrieval {
   def getSchemaInfo(config: Config): SchemaInfo = {
     val DbMetadataQueryResult(tables, columns, primaryKeys, foreignKeys, dbVendor) = DbMetadataQueries.queryDb(config)
@@ -17,7 +19,10 @@ object SchemaInfoRetrieval {
       columns
         .groupBy(c => tablesByName(c.schema, c.table))
         .map { case (table, cols) =>
-          table -> cols.zipWithIndex.map { case (c, i) => c.name -> new Column(table, c.name, i, c.jdbcType, c.typeName) }.toMap
+          table -> cols.zipWithIndex.map { case (c, i) =>
+            val columnType: ColumnType = ColumnTypes.fromRawInfo(c.jdbcType, c.typeName, dbVendor)
+            c.name -> new Column(table, c.name, i, columnType)
+          }.toMap
         }
     }
 

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -1,6 +1,8 @@
 package trw.dbsubsetter
 
-import java.sql.{Connection, JDBCType}
+import java.sql.Connection
+
+import trw.dbsubsetter.db.ColumnTypes.ColumnType
 
 package object db {
   type SchemaName = String
@@ -32,8 +34,7 @@ package object db {
     val table: Table,
     val name: ColumnName,
     val ordinalPosition: Int,
-    val jdbcType: JDBCType,
-    val typeName: String
+    val dataType: ColumnType
   )
 
   class ForeignKey(

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -20,8 +20,7 @@ package object db {
     val pksByTableOrdered: Map[Table, Vector[Column]],
     val fksOrdered: Array[ForeignKey],
     val fksFromTable: Map[Table, Vector[ForeignKey]],
-    val fksToTable: Map[Table, Vector[ForeignKey]],
-    val dbVendor: DbVendor
+    val fksToTable: Map[Table, Vector[ForeignKey]]
   )
 
   class Table(

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFkTaskQueue.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFkTaskQueue.scala
@@ -43,16 +43,15 @@ private[offheap] final class ChronicleQueueFkTaskQueue(config: Config, schemaInf
   private[this] val parentFkWriters =
     schemaInfo
       .fksOrdered
-      .zipWithIndex.map { case (fk, i) =>
-        new TaskQueueWriter(i.toShort, fk.toCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor)
+      .map { fk =>
+        new TaskQueueWriter(fk.i, fk.toCols.map(_.dataType))
       }
 
   private[this] val childFkWriters =
     schemaInfo
       .fksOrdered
-      .zipWithIndex
-      .map { case (fk, i) =>
-        new TaskQueueWriter(i.toShort, fk.fromCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor)
+      .map { fk =>
+        new TaskQueueWriter(fk.i, fk.fromCols.map(_.dataType))
       }
 
   override def enqueue(fkOrdinal: Short, fkValue: Any, fetchChildren: Boolean): Unit = {

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFkTaskQueue.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFkTaskQueue.scala
@@ -6,7 +6,7 @@ import net.openhft.chronicle.queue.RollCycles
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueueBuilder
 import net.openhft.chronicle.wire.WriteMarshallable
 import trw.dbsubsetter.config.Config
-import trw.dbsubsetter.db.SchemaInfo
+import trw.dbsubsetter.db.{ForeignKey, SchemaInfo}
 import trw.dbsubsetter.workflow.offheap.OffHeapFkTaskQueue
 import trw.dbsubsetter.workflow.{ForeignKeyTask, RawTaskToForeignKeyTaskMapper}
 
@@ -24,27 +24,48 @@ private[offheap] final class ChronicleQueueFkTaskQueue(config: Config, schemaInf
       .rollCycle(RollCycles.MINUTELY)
       .build()
 
-  private[this] val appender =
-    queue.acquireAppender()
+  private[this] val appender = queue.acquireAppender()
 
-  private[this] val tailer =
-    queue.createTailer()
+  private[this] val tailer = queue.createTailer()
 
   private[this] val childReaders =
-    schemaInfo.fksOrdered.map(fk => new TaskQueueReader(fk.fromCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor))
+    schemaInfo
+      .fksOrdered
+      .map { fk =>
+        new TaskQueueReader(fk.fromCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor)
+      }
 
   private[this] val parentReaders =
-    schemaInfo.fksOrdered.map(fk => new TaskQueueReader(fk.toCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor))
+    schemaInfo.fksOrdered.map { fk =>
+      new TaskQueueReader(fk.toCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor)
+    }
 
   private[this] val parentFkWriters =
-    schemaInfo.fksOrdered.zipWithIndex.map { case (fk, i) => new TaskQueueWriter(i.toShort, fk.toCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor) }
+    schemaInfo
+      .fksOrdered
+      .zipWithIndex.map { case (fk, i) =>
+        new TaskQueueWriter(i.toShort, fk.toCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor)
+      }
 
   private[this] val childFkWriters =
-    schemaInfo.fksOrdered.zipWithIndex.map { case (fk, i) => new TaskQueueWriter(i.toShort, fk.fromCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor) }
+    schemaInfo
+      .fksOrdered
+      .zipWithIndex
+      .map { case (fk, i) =>
+        new TaskQueueWriter(i.toShort, fk.fromCols.map(c => (c.jdbcType, c.typeName)), schemaInfo.dbVendor)
+      }
 
   override def enqueue(fkOrdinal: Short, fkValue: Any, fetchChildren: Boolean): Unit = {
-    val writer = if (fetchChildren) childFkWriters(fkOrdinal) else parentFkWriters(fkOrdinal)
-    val writeMarshallable: WriteMarshallable = writer.writeHandler(fetchChildren, fkValue)
+    val writer: TaskQueueWriter =
+      if (fetchChildren) {
+        childFkWriters(fkOrdinal)
+      } else {
+        parentFkWriters(fkOrdinal)
+      }
+
+    val writeMarshallable: WriteMarshallable =
+      writer.writeHandler(fetchChildren, fkValue)
+
     appender.writeDocument(writeMarshallable)
   }
 
@@ -58,13 +79,15 @@ private[offheap] final class ChronicleQueueFkTaskQueue(config: Config, schemaInf
     tailer.readDocument { r =>
       val in = r.getValueIn
 
-      val fetchChildren = in.bool()
-      val fkOrdinal = in.int16()
-      val reader = if (fetchChildren) childReaders(fkOrdinal) else parentReaders(fkOrdinal)
-      val fkValue = reader.read(in)
-      val fk = schemaInfo.fksOrdered(fkOrdinal)
+      val fetchChildren: Boolean = in.bool()
+      val fkOrdinal: Short = in.int16()
+      val reader: TaskQueueReader = if (fetchChildren) childReaders(fkOrdinal) else parentReaders(fkOrdinal)
+      val fkValue: Any = reader.read(in)
+      val foreignKey: ForeignKey = schemaInfo.fksOrdered(fkOrdinal)
 
-      val task: ForeignKeyTask = RawTaskToForeignKeyTaskMapper.map(fk, fetchChildren, fkValue)
+      val task: ForeignKeyTask =
+        RawTaskToForeignKeyTaskMapper.map(foreignKey, fetchChildren, fkValue)
+
       optionalTask = Some(task)
     }
 

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
@@ -1,7 +1,6 @@
 package trw.dbsubsetter.workflow.offheap.impl.chroniclequeue
 
 import java.sql.JDBCType
-import java.util.UUID
 
 import net.openhft.chronicle.wire.ValueIn
 import trw.dbsubsetter.db.{DbVendor, TypeName}
@@ -30,7 +29,7 @@ private[offheap] final class TaskQueueReader(typeList: Seq[(JDBCType, TypeName)]
       case (JDBCType.BINARY | JDBCType.VARBINARY | JDBCType.LONGVARBINARY, _, _) =>
         (in: ValueIn) => in.bytes()
       case (_, "uuid", PostgreSQL) =>
-        (in: ValueIn) => UUID.fromString(in.text()) // TODO optimize to use byte[] instead of string
+        (in: ValueIn) => in.uuid()
       case (otherJDBCType, otherTypeName, _) =>
         throw new RuntimeException(s"Type not yet supported for foreign key. JDBC Type: $otherJDBCType. Type Name: $otherTypeName. Please open a GitHub issue for this.")
     }

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
@@ -1,40 +1,40 @@
 package trw.dbsubsetter.workflow.offheap.impl.chroniclequeue
 
-import java.sql.JDBCType
-
 import net.openhft.chronicle.wire.ValueIn
-import trw.dbsubsetter.db.{DbVendor, TypeName}
+import trw.dbsubsetter.db.ColumnTypes
+import trw.dbsubsetter.db.ColumnTypes.ColumnType
 
-private[offheap] final class TaskQueueReader(typeList: Seq[(JDBCType, TypeName)], dbVendor: DbVendor) {
-  def read(in: ValueIn): Any = handlerFunc(in)
+private[offheap] final class TaskQueueReader(columnTypes: Seq[ColumnType]) {
+
+  def read(in: ValueIn): Any = {
+    handlerFunc(in)
+  }
 
   private val handlerFunc: ValueIn => Any = {
-    import DbVendor._
+    val funcs: Seq[ValueIn => Any] =
+      columnTypes.map {
+        case ColumnTypes.Short =>
+          (in: ValueIn) => in.int16()
+        case ColumnTypes.Int =>
+          (in: ValueIn) => in.int32()
+        case ColumnTypes.Long =>
+          (in: ValueIn) => in.int64()
+        case ColumnTypes.BigInteger =>
+          (in: ValueIn) => in.`object`()
+        case ColumnTypes.String =>
+          (in: ValueIn) => in.text()
+        case ColumnTypes.ByteArray =>
+          (in: ValueIn) => in.bytes()
+        case ColumnTypes.Uuid =>
+          (in: ValueIn) => in.uuid()
+        case ColumnTypes.Unknown(description) =>
+          val errorMessage =
+            s"Column type not yet fully supported: $description. " +
+              "Please open a GitHub issue and we will try to address it promptly."
+          throw new RuntimeException(errorMessage)
+      }
 
-    val typeListWithVendors = typeList.map { case (jdbc, name) => (jdbc, name, dbVendor) }
-
-    val funcs: Seq[ValueIn => Any] = typeListWithVendors.map {
-      case (JDBCType.TINYINT | JDBCType.SMALLINT, _, MicrosoftSQLServer) =>
-        (in: ValueIn) => in.int16()
-      case (JDBCType.INTEGER, "INT UNSIGNED", MySQL) =>
-        (in: ValueIn) => in.int64()
-      case (JDBCType.TINYINT | JDBCType.SMALLINT | JDBCType.INTEGER, _, _) =>
-        (in: ValueIn) => in.int32()
-      case (JDBCType.BIGINT, "BIGINT UNSIGNED", MySQL) =>
-        (in: ValueIn) => in.`object`()
-      case (JDBCType.BIGINT, _, _) =>
-        (in: ValueIn) => in.int64()
-      case (JDBCType.VARCHAR | JDBCType.CHAR | JDBCType.LONGVARCHAR | JDBCType.NCHAR, _, _) =>
-        (in: ValueIn) => in.text()
-      case (JDBCType.BINARY | JDBCType.VARBINARY | JDBCType.LONGVARBINARY, _, _) =>
-        (in: ValueIn) => in.bytes()
-      case (_, "uuid", PostgreSQL) =>
-        (in: ValueIn) => in.uuid()
-      case (otherJDBCType, otherTypeName, _) =>
-        throw new RuntimeException(s"Type not yet supported for foreign key. JDBC Type: $otherJDBCType. Type Name: $otherTypeName. Please open a GitHub issue for this.")
-    }
-
-    if (typeList.size == 1) {
+    if (columnTypes.size == 1) {
       in: ValueIn => funcs.head(in)
     } else {
       in: ValueIn => funcs.toArray.map(f => f(in))

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
@@ -7,10 +7,10 @@ import trw.dbsubsetter.db.ColumnTypes.ColumnType
 private[offheap] final class TaskQueueReader(columnTypes: Seq[ColumnType]) {
 
   def read(in: ValueIn): Any = {
-    handlerFunc(in)
+    valueReader(in)
   }
 
-  private val handlerFunc: ValueIn => Any = {
+  private val valueReader: ValueIn => Any = {
     val funcs: Seq[ValueIn => Any] =
       columnTypes.map {
         case ColumnTypes.Short =>

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
@@ -34,10 +34,8 @@ private[offheap] final class TaskQueueReader(typeList: Seq[(JDBCType, TypeName)]
         throw new RuntimeException(s"Type not yet supported for foreign key. JDBC Type: $otherJDBCType. Type Name: $otherTypeName. Please open a GitHub issue for this.")
     }
 
-    val headFunc: ValueIn => Any = funcs.head
-
-    if (typeList.lengthCompare(1) == 0) {
-      in: ValueIn => headFunc(in)
+    if (typeList.size == 1) {
+      in: ValueIn => funcs.head(in)
     } else {
       in: ValueIn => funcs.toArray.map(f => f(in))
     }

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
@@ -41,7 +41,7 @@ private[offheap] final class TaskQueueWriter(fkOrdinal: Short, columnTypes: Seq[
           throw new RuntimeException(errorMessage)
       }
 
-    if (columns.size == 1) {
+    if (columnTypes.size == 1) {
       (out, fkValue) => funcs.head(out, fkValue)
     } else {
       (out, fkValues) => fkValues.asInstanceOf[Array[Any]].zip(funcs).foreach { case (v, f) => f(out, v) }

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
@@ -42,10 +42,8 @@ private[offheap] final class TaskQueueWriter(fkOrdinal: Short, typeList: Seq[(JD
         throw new RuntimeException(s"Type not yet supported for foreign key. JDBC Type: $otherJDBCType. Type Name: $otherTypeName. Please open a GitHub issue for this.")
     }
 
-    val headFunc: (ValueOut, Any) => WireOut = funcs.head
-
     if (typeList.lengthCompare(1) == 0) {
-      (out, fkValue) => headFunc(out, fkValue)
+      (out, fkValue) => funcs.head(out, fkValue)
     } else {
       (out, fkValues) => fkValues.asInstanceOf[Array[Any]].zip(funcs).foreach { case (v, f) => f(out, v) }
     }

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
@@ -37,7 +37,7 @@ private[offheap] final class TaskQueueWriter(fkOrdinal: Short, typeList: Seq[(JD
       case (JDBCType.BINARY | JDBCType.VARBINARY | JDBCType.LONGVARBINARY, _, _) =>
         (out: ValueOut, fkVal: Any) => out.bytes(fkVal.asInstanceOf[Array[Byte]])
       case (_, "uuid", PostgreSQL) =>
-        (out: ValueOut, fkVal: Any) => out.text(fkVal.asInstanceOf[UUID].toString) // TODO optimize to use byte[] instead of string
+        (out: ValueOut, fkVal: Any) => out.uuid(fkVal.asInstanceOf[UUID])
       case (otherJDBCType, otherTypeName, _) =>
         throw new RuntimeException(s"Type not yet supported for foreign key. JDBC Type: $otherJDBCType. Type Name: $otherTypeName. Please open a GitHub issue for this.")
     }

--- a/src/test/scala/integration/OffHeapTaskQueueTest.scala
+++ b/src/test/scala/integration/OffHeapTaskQueueTest.scala
@@ -1,10 +1,8 @@
 package integration
 
-import java.sql.JDBCType
-
 import org.scalatest.FunSuite
 import trw.dbsubsetter.config.Config
-import trw.dbsubsetter.db.{Column, ForeignKey, SchemaInfo, Table}
+import trw.dbsubsetter.db.{Column, ColumnTypes, ForeignKey, SchemaInfo, Table}
 import trw.dbsubsetter.workflow.FetchParentTask
 import trw.dbsubsetter.workflow.offheap.OffHeapFkTaskQueueFactory
 
@@ -75,8 +73,7 @@ private[this] object OffHeapTaskQueueTest {
       table = parentTable,
       name = "id",
       ordinalPosition = 4,
-      jdbcType = JDBCType.BIGINT,
-      typeName = "whatever"
+      ColumnTypes.Long
     )
 
   private[this] val childTable: Table =
@@ -91,8 +88,7 @@ private[this] object OffHeapTaskQueueTest {
       table = childTable,
       name = "parentId",
       ordinalPosition = 7,
-      jdbcType = JDBCType.BIGINT,
-      typeName = "whatever"
+      ColumnTypes.Long
     )
 
   private val foreignKey: ForeignKey =
@@ -110,7 +106,6 @@ private[this] object OffHeapTaskQueueTest {
       pksByTableOrdered = Map.empty,
       fksOrdered = Array(foreignKey),
       fksFromTable = Map.empty,
-      fksToTable = Map.empty,
-      dbVendor = null
+      fksToTable = Map.empty
     )
 }

--- a/src/test/scala/unit/PkStoreTest.scala
+++ b/src/test/scala/unit/PkStoreTest.scala
@@ -19,8 +19,7 @@ class PkStoreTest extends FunSuite {
         table = table,
         name = null,
         ordinalPosition = 0,
-        jdbcType = null,
-        typeName = null
+        dataType = null
       )
 
     val schemaInfo: SchemaInfo =
@@ -30,8 +29,7 @@ class PkStoreTest extends FunSuite {
         pksByTableOrdered = Map(table -> Vector(pkCol)),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,
-        fksToTable = Map.empty,
-        dbVendor = null
+        fksToTable = Map.empty
       )
 
     val pkStore: PrimaryKeyStore =

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -20,8 +20,7 @@ class PkStoreWorkflowTest extends FunSuite {
         table = table,
         name = null,
         ordinalPosition = 0,
-        jdbcType = null,
-        typeName = null
+        dataType = null
       )
 
     val schemaInfo: SchemaInfo =
@@ -31,8 +30,7 @@ class PkStoreWorkflowTest extends FunSuite {
         pksByTableOrdered = Map(table -> Vector(pkCol)),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,
-        fksToTable = Map.empty,
-        dbVendor = null
+        fksToTable = Map.empty
       )
 
     val pkStore: PrimaryKeyStore =
@@ -84,8 +82,7 @@ class PkStoreWorkflowTest extends FunSuite {
         table = table,
         name = null,
         ordinalPosition = 0,
-        jdbcType = null,
-        typeName = null
+        dataType = null
       )
 
     val schemaInfo: SchemaInfo =
@@ -95,8 +92,7 @@ class PkStoreWorkflowTest extends FunSuite {
         pksByTableOrdered = Map(table -> Vector(primaryKeyColumn)),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,
-        fksToTable = Map.empty,
-        dbVendor = null
+        fksToTable = Map.empty
       )
 
     val pkStore: PrimaryKeyStore =


### PR DESCRIPTION
A preparatory refactor which should make it easier to eventually accomplish https://github.com/bluerogue251/DBSubsetter/issues/33

Cleans up chronicle queue code a bit to make it easier to extend later to include queueing up primary key values for consumption by the data copying feature.