### PR TITLE
Chronicle queue refactors [Part 2]

### DIFF
--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFunctions.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFunctions.scala
@@ -9,7 +9,7 @@ import trw.dbsubsetter.db.ColumnTypes.ColumnType
 
 object ChronicleQueueFunctions {
 
-  def resolveReadFunction(dataType: ColumnType): ValueIn => Any = {
+  def singleValueRead(dataType: ColumnType): ValueIn => Any = {
     dataType match {
       case ColumnTypes.Short =>
         (in: ValueIn) => in.int16()
@@ -33,7 +33,7 @@ object ChronicleQueueFunctions {
     }
   }
 
-  def resolveWriteFunction(dataType: ColumnType): (ValueOut, Any) => WireOut = {
+  def singleValueWrite(dataType: ColumnType): (ValueOut, Any) => WireOut = {
     dataType match {
       case ColumnTypes.Short =>
         (out: ValueOut, fkVal: Any) => out.int16(fkVal.asInstanceOf[Short])
@@ -51,8 +51,8 @@ object ChronicleQueueFunctions {
         (out: ValueOut, fkVal: Any) => out.uuid(fkVal.asInstanceOf[UUID])
       case ColumnTypes.Unknown(description) =>
         val errorMessage =
-        s"Column type not yet fully supported: $description. " +
-        "Please open a GitHub issue and we will try to address it promptly."
+          s"Column type not yet fully supported: $description. " +
+            "Please open a GitHub issue and we will try to address it promptly."
         throw new RuntimeException(errorMessage)
     }
   }

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFunctions.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/ChronicleQueueFunctions.scala
@@ -1,0 +1,59 @@
+package trw.dbsubsetter.workflow.offheap.impl.chroniclequeue
+
+import java.math.BigInteger
+import java.util.UUID
+
+import net.openhft.chronicle.wire.{ValueIn, ValueOut, WireOut}
+import trw.dbsubsetter.db.ColumnTypes
+import trw.dbsubsetter.db.ColumnTypes.ColumnType
+
+object ChronicleQueueFunctions {
+
+  def resolveReadFunction(dataType: ColumnType): ValueIn => Any = {
+    dataType match {
+      case ColumnTypes.Short =>
+        (in: ValueIn) => in.int16()
+      case ColumnTypes.Int =>
+        (in: ValueIn) => in.int32()
+      case ColumnTypes.Long =>
+        (in: ValueIn) => in.int64()
+      case ColumnTypes.BigInteger =>
+        (in: ValueIn) => in.`object`()
+      case ColumnTypes.String =>
+        (in: ValueIn) => in.text()
+      case ColumnTypes.ByteArray =>
+        (in: ValueIn) => in.bytes()
+      case ColumnTypes.Uuid =>
+        (in: ValueIn) => in.uuid()
+      case ColumnTypes.Unknown(description) =>
+        val errorMessage =
+          s"Column type not yet fully supported: $description. " +
+            "Please open a GitHub issue and we will try to address it promptly."
+        throw new RuntimeException(errorMessage)
+    }
+  }
+
+  def resolveWriteFunction(dataType: ColumnType): (ValueOut, Any) => WireOut = {
+    dataType match {
+      case ColumnTypes.Short =>
+        (out: ValueOut, fkVal: Any) => out.int16(fkVal.asInstanceOf[Short])
+      case ColumnTypes.Int =>
+        (out: ValueOut, fkVal: Any) => out.int32(fkVal.asInstanceOf[Int])
+      case ColumnTypes.Long =>
+        (out: ValueOut, fkVal: Any) => out.int64(fkVal.asInstanceOf[Long])
+      case ColumnTypes.BigInteger =>
+        (out: ValueOut, fkVal: Any) => out.`object`(fkVal.asInstanceOf[BigInteger])
+      case ColumnTypes.String =>
+        (out: ValueOut, fkVal: Any) => out.text(fkVal.asInstanceOf[String])
+      case ColumnTypes.ByteArray =>
+        (out: ValueOut, fkVal: Any) => out.bytes(fkVal.asInstanceOf[Array[Byte]])
+      case ColumnTypes.Uuid =>
+        (out: ValueOut, fkVal: Any) => out.uuid(fkVal.asInstanceOf[UUID])
+      case ColumnTypes.Unknown(description) =>
+        val errorMessage =
+        s"Column type not yet fully supported: $description. " +
+        "Please open a GitHub issue and we will try to address it promptly."
+        throw new RuntimeException(errorMessage)
+    }
+  }
+}

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
@@ -7,7 +7,7 @@ import trw.dbsubsetter.db.ColumnTypes.ColumnType
 private[offheap] final class TaskQueueReader(columnTypes: Seq[ColumnType]) {
   private[this] val valueReader: ValueIn => Any = {
     val funcs: Seq[ValueIn => Any] =
-      columnTypes.map(ChronicleQueueFunctions.resolveReadFunction)
+      columnTypes.map(ChronicleQueueFunctions.singleValueRead)
 
     if (columnTypes.size == 1) {
       in: ValueIn => funcs.head(in)

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueReader.scala
@@ -1,43 +1,22 @@
 package trw.dbsubsetter.workflow.offheap.impl.chroniclequeue
 
 import net.openhft.chronicle.wire.ValueIn
-import trw.dbsubsetter.db.ColumnTypes
 import trw.dbsubsetter.db.ColumnTypes.ColumnType
 
+
 private[offheap] final class TaskQueueReader(columnTypes: Seq[ColumnType]) {
-
-  def read(in: ValueIn): Any = {
-    valueReader(in)
-  }
-
-  private val valueReader: ValueIn => Any = {
+  private[this] val valueReader: ValueIn => Any = {
     val funcs: Seq[ValueIn => Any] =
-      columnTypes.map {
-        case ColumnTypes.Short =>
-          (in: ValueIn) => in.int16()
-        case ColumnTypes.Int =>
-          (in: ValueIn) => in.int32()
-        case ColumnTypes.Long =>
-          (in: ValueIn) => in.int64()
-        case ColumnTypes.BigInteger =>
-          (in: ValueIn) => in.`object`()
-        case ColumnTypes.String =>
-          (in: ValueIn) => in.text()
-        case ColumnTypes.ByteArray =>
-          (in: ValueIn) => in.bytes()
-        case ColumnTypes.Uuid =>
-          (in: ValueIn) => in.uuid()
-        case ColumnTypes.Unknown(description) =>
-          val errorMessage =
-            s"Column type not yet fully supported: $description. " +
-              "Please open a GitHub issue and we will try to address it promptly."
-          throw new RuntimeException(errorMessage)
-      }
+      columnTypes.map(ChronicleQueueFunctions.resolveReadFunction)
 
     if (columnTypes.size == 1) {
       in: ValueIn => funcs.head(in)
     } else {
       in: ValueIn => funcs.toArray.map(f => f(in))
     }
+  }
+
+  def read(in: ValueIn): Any = {
+    valueReader(in)
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
@@ -1,50 +1,27 @@
 package trw.dbsubsetter.workflow.offheap.impl.chroniclequeue
 
-import java.math.BigInteger
-import java.util.UUID
-
 import net.openhft.chronicle.wire.{ValueOut, WireOut, WriteMarshallable}
-import trw.dbsubsetter.db.ColumnTypes
 import trw.dbsubsetter.db.ColumnTypes.ColumnType
 
+
 private[offheap] final class TaskQueueWriter(fkOrdinal: Short, columnTypes: Seq[ColumnType]) {
+  private[this] val valueWriter: (ValueOut, Any) => Unit = {
+    val funcs: Seq[(ValueOut, Any) => WireOut] =
+      columnTypes.map(ChronicleQueueFunctions.resolveWriteFunction)
+
+    if (columnTypes.size == 1) {
+      (out, fkValue) => funcs.head(out, fkValue)
+    } else {
+      (out, fkValues) => fkValues.asInstanceOf[Array[Any]].zip(funcs).foreach { case (v, f) => f(out, v) }
+    }
+  }
+
   def writeHandler(fetchChildren: Boolean, fkValue: Any): WriteMarshallable = {
     wireOut => {
       val out = wireOut.getValueOut
       out.bool(fetchChildren)
       out.int16(fkOrdinal)
       valueWriter(out, fkValue)
-    }
-  }
-
-  private val valueWriter: (ValueOut, Any) => Unit = {
-    val funcs: Seq[(ValueOut, Any) => WireOut] =
-      columnTypes.map {
-        case ColumnTypes.Short =>
-          (out: ValueOut, fkVal: Any) => out.int16(fkVal.asInstanceOf[Short])
-        case ColumnTypes.Int =>
-          (out: ValueOut, fkVal: Any) => out.int32(fkVal.asInstanceOf[Int])
-        case ColumnTypes.Long =>
-          (out: ValueOut, fkVal: Any) => out.int64(fkVal.asInstanceOf[Long])
-        case ColumnTypes.BigInteger =>
-          (out: ValueOut, fkVal: Any) => out.`object`(fkVal.asInstanceOf[BigInteger])
-        case ColumnTypes.String =>
-          (out: ValueOut, fkVal: Any) => out.text(fkVal.asInstanceOf[String])
-        case ColumnTypes.ByteArray =>
-          (out: ValueOut, fkVal: Any) => out.bytes(fkVal.asInstanceOf[Array[Byte]])
-        case ColumnTypes.Uuid =>
-          (out: ValueOut, fkVal: Any) => out.uuid(fkVal.asInstanceOf[UUID])
-        case ColumnTypes.Unknown(description) =>
-          val errorMessage =
-            s"Column type not yet fully supported: $description. " +
-            "Please open a GitHub issue and we will try to address it promptly."
-          throw new RuntimeException(errorMessage)
-      }
-
-    if (columnTypes.size == 1) {
-      (out, fkValue) => funcs.head(out, fkValue)
-    } else {
-      (out, fkValues) => fkValues.asInstanceOf[Array[Any]].zip(funcs).foreach { case (v, f) => f(out, v) }
     }
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/offheap/impl/chroniclequeue/TaskQueueWriter.scala
@@ -7,7 +7,7 @@ import trw.dbsubsetter.db.ColumnTypes.ColumnType
 private[offheap] final class TaskQueueWriter(fkOrdinal: Short, columnTypes: Seq[ColumnType]) {
   private[this] val valueWriter: (ValueOut, Any) => Unit = {
     val funcs: Seq[(ValueOut, Any) => WireOut] =
-      columnTypes.map(ChronicleQueueFunctions.resolveWriteFunction)
+      columnTypes.map(ChronicleQueueFunctions.singleValueWrite)
 
     if (columnTypes.size == 1) {
       (out, fkValue) => funcs.head(out, fkValue)


### PR DESCRIPTION
Part 2 of a preparatory refactor which should make it easier to eventually accomplish https://github.com/bluerogue251/DBSubsetter/issues/33

Cleans up chronicle queue code a bit to make it easier to extend later to include queueing up primary key values for consumption by the data copying feature. Specifically, extract helpers which map from a single column type to the chronicle queue function that can write or read a single value of that column type. This will then be leveraged for writing and reading primary key column data.