### PR TITLE
Increase type safety of Primary Key type

### DIFF
--- a/src/main/scala/trw/dbsubsetter/datacopyqueue/impl/DataCopyQueueImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/datacopyqueue/impl/DataCopyQueueImpl.scala
@@ -29,9 +29,9 @@ private[datacopyqueue] final class DataCopyQueueImpl(config: Config, schemaInfo:
 
   private[this] val tablesToChronicleQueues: Map[Table, ChronicleQueueAccess] = {
     schemaInfo
-      .pksByTableOrdered
-      .map { case (table, primaryKeyColumns) =>
-        val columnTypes: Seq[ColumnType] = primaryKeyColumns.map(_.dataType)
+      .pksByTable
+      .map { case (table, primaryKey) =>
+        val columnTypes: Seq[ColumnType] = primaryKey.columns.map(_.dataType)
         table -> new ChronicleQueueAccess(config, columnTypes)
       }
   }

--- a/src/main/scala/trw/dbsubsetter/db/Sql.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Sql.scala
@@ -23,9 +23,10 @@ private[db] object Sql {
   }
 
   def queryByPkSqlTemplates(sch: SchemaInfo): PrimaryKeySqlTemplates = {
-    sch.pksByTableOrdered.flatMap { case (table, primaryKeyColumns) =>
+    sch.pksByTable.flatMap { case (table, primaryKey) =>
       Constants.dataCopyBatchSizes.map(batchSize => {
-        val whereClause: String = makeCompositeWhereClause(primaryKeyColumns, batchSize)
+        val columns: Seq[Column] = primaryKey.columns
+        val whereClause: String = makeCompositeWhereClause(columns, batchSize)
         (table, batchSize) -> makeQueryString(table, whereClause, sch)
       })
     }

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -61,17 +61,6 @@ package object db {
     val isEmpty: Boolean = individualColumnValues.forall(_ == null)
   }
 
-  // Represents a single row in the origin database including only primary and foreign key columns
-  class Keys(data: Array[Any]) {
-    def getValue(primaryKey: PrimaryKey): PrimaryKeyValue = {
-      ???
-    }
-
-    def getValue(foreignKey: ForeignKey): ForeignKeyValue = {
-      ???
-    }
-  }
-
   implicit class VendorAwareJdbcConnection(private val conn: Connection) {
     private val vendorName: String = conn.getMetaData.getDatabaseProductName
 

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -18,7 +18,7 @@ package object db {
   class SchemaInfo(
     val tablesByName: Map[(SchemaName, TableName), Table],
     val colsByTableOrdered: Map[Table, Vector[Column]],
-    val pksByTableOrdered: Map[Table, Vector[Column]],
+    val pksByTable: Map[Table, PrimaryKey],
     val fksOrdered: Array[ForeignKey],
     val fksFromTable: Map[Table, Vector[ForeignKey]],
     val fksToTable: Map[Table, Vector[ForeignKey]]
@@ -36,6 +36,8 @@ package object db {
     val ordinalPosition: Int,
     val dataType: ColumnType
   )
+
+  class PrimaryKey(val columns: Seq[Column])
 
   class ForeignKey(
     val fromCols: Vector[Column],
@@ -57,6 +59,17 @@ package object db {
   // Foreign keys can be multi-column. Therefore a single foreign key value is a sequence of individual column values.
   class ForeignKeyValue(val individualColumnValues: Seq[Any]) {
     val isEmpty: Boolean = individualColumnValues.forall(_ == null)
+  }
+
+  // Represents a single row in the origin database including only primary and foreign key columns
+  class Keys(data: Array[Any]) {
+    def getValue(primaryKey: PrimaryKey): PrimaryKeyValue = {
+      ???
+    }
+
+    def getValue(foreignKey: ForeignKey): ForeignKeyValue = {
+      ???
+    }
   }
 
   implicit class VendorAwareJdbcConnection(private val conn: Connection) {

--- a/src/main/scala/trw/dbsubsetter/keyextraction/KeyExtractionUtil.scala
+++ b/src/main/scala/trw/dbsubsetter/keyextraction/KeyExtractionUtil.scala
@@ -5,8 +5,8 @@ import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, PrimaryKeyValue, Row, Sc
 object KeyExtractionUtil {
 
   def pkExtractionFunctions(schemaInfo: SchemaInfo): Map[Table, Row => PrimaryKeyValue] = {
-    schemaInfo.pksByTableOrdered.map { case (table, primaryKeyColumns) =>
-      val primaryKeyColumnOrdinals: Vector[Int] = primaryKeyColumns.map(_.ordinalPosition)
+    schemaInfo.pksByTable.map { case (table, primaryKey) =>
+      val primaryKeyColumnOrdinals: Seq[Int] = primaryKey.columns.map(_.ordinalPosition)
       val primaryKeyExtractionFunction: Row => PrimaryKeyValue = row => {
         val individualColumnValues: Seq[Any] = primaryKeyColumnOrdinals.map(row)
         new PrimaryKeyValue(individualColumnValues)

--- a/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
+++ b/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
@@ -72,7 +72,7 @@ private[primarykeystore] final class InMemoryPrimaryKeyStore(schemaInfo: SchemaI
 
 private object InMemoryPrimaryKeyStore {
   private def buildStorage(schemaInfo: SchemaInfo): Map[Table, mutable.HashSet[Any]] = {
-    val tables: Iterable[Table] = schemaInfo.pksByTableOrdered.keys
+    val tables: Iterable[Table] = schemaInfo.pksByTable.keys
     tables.map { t => t -> mutable.HashSet.empty[Any] }.toMap
   }
 

--- a/src/test/scala/integration/OffHeapTaskQueueTest.scala
+++ b/src/test/scala/integration/OffHeapTaskQueueTest.scala
@@ -114,7 +114,7 @@ private[this] object OffHeapTaskQueueTest {
     new SchemaInfo(
       tablesByName = Map.empty,
       colsByTableOrdered = Map.empty,
-      pksByTableOrdered = Map.empty,
+      pksByTable = Map.empty,
       fksOrdered = Array(foreignKey),
       fksFromTable = Map.empty,
       fksToTable = Map.empty

--- a/src/test/scala/unit/PkStoreTest.scala
+++ b/src/test/scala/unit/PkStoreTest.scala
@@ -2,7 +2,7 @@ package unit
 
 import org.scalatest.FunSuite
 import trw.dbsubsetter.config.Config
-import trw.dbsubsetter.db.{Column, PrimaryKeyValue, SchemaInfo, Table}
+import trw.dbsubsetter.db.{Column, PrimaryKey, PrimaryKeyValue, SchemaInfo, Table}
 import trw.dbsubsetter.primarykeystore._
 
 class PkStoreTest extends FunSuite {
@@ -26,7 +26,7 @@ class PkStoreTest extends FunSuite {
       new SchemaInfo(
         tablesByName = Map.empty,
         colsByTableOrdered = Map.empty,
-        pksByTableOrdered = Map(table -> Vector(pkCol)),
+        pksByTable = Map(table -> new PrimaryKey(Seq(pkCol))),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,
         fksToTable = Map.empty

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -2,7 +2,7 @@ package unit
 
 import org.scalatest.FunSuite
 import trw.dbsubsetter.config.Config
-import trw.dbsubsetter.db.{Column, PrimaryKeyValue, Row, SchemaInfo, Table}
+import trw.dbsubsetter.db.{Column, PrimaryKey, PrimaryKeyValue, Row, SchemaInfo, Table}
 import trw.dbsubsetter.primarykeystore.{PrimaryKeyStore, PrimaryKeyStoreFactory}
 import trw.dbsubsetter.workflow._
 
@@ -27,7 +27,7 @@ class PkStoreWorkflowTest extends FunSuite {
       new SchemaInfo(
         tablesByName = Map.empty,
         colsByTableOrdered = Map.empty,
-        pksByTableOrdered = Map(table -> Vector(pkCol)),
+        pksByTable = Map(table -> new PrimaryKey(Seq(pkCol))),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,
         fksToTable = Map.empty
@@ -91,7 +91,7 @@ class PkStoreWorkflowTest extends FunSuite {
       new SchemaInfo(
         tablesByName = Map.empty,
         colsByTableOrdered = Map.empty,
-        pksByTableOrdered = Map(table -> Vector(primaryKeyColumn)),
+        pksByTable = Map(table -> new PrimaryKey(Seq(primaryKeyColumn))),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,
         fksToTable = Map.empty


### PR DESCRIPTION
* Make `PrimaryKey` a fully fledged type, as opposed to being represented by a `Vector[Column]`.
* The goal is eventually to have a type called `Keys` with `get(pk: PrimaryKey): PrimaryKeyValue` and `get(fk: ForeignKey): ForeignKeyValue`, so that we can have the concept of a row from the origin database which only contains key columns, not regular data columns, with a typesafe way of enforcing that we never try to access regular data columns.

Contributes towards step 5 (post merge cleanup work) in https://github.com/bluerogue251/DBSubsetter/issues/33