### PR TITLE
Separate types for Key-only-row-data and Full-row-data

### DIFF
--- a/src/main/scala/trw/dbsubsetter/datacopyqueue/impl/DataCopyQueueImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/datacopyqueue/impl/DataCopyQueueImpl.scala
@@ -3,7 +3,7 @@ package trw.dbsubsetter.datacopyqueue.impl
 import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.datacopyqueue.DataCopyQueue
 import trw.dbsubsetter.db.ColumnTypes.ColumnType
-import trw.dbsubsetter.db.{Constants, PrimaryKeyValue, Row, SchemaInfo, Table}
+import trw.dbsubsetter.db.{Constants, Keys, PrimaryKeyValue, SchemaInfo, Table}
 import trw.dbsubsetter.keyextraction.KeyExtractionUtil
 import trw.dbsubsetter.workflow.{DataCopyTask, PksAdded}
 
@@ -36,11 +36,11 @@ private[datacopyqueue] final class DataCopyQueueImpl(config: Config, schemaInfo:
       }
   }
 
-  private[this] val pkValueExtractionFunctions: Map[Table, Row => PrimaryKeyValue] =
+  private[this] val pkValueExtractionFunctions: Map[Table, Keys => PrimaryKeyValue] =
     KeyExtractionUtil.pkExtractionFunctions(schemaInfo)
 
   override def enqueue(pksAdded: PksAdded): Unit = {
-    val rows: Vector[Row] = pksAdded.rowsNeedingParentTasks
+    val rows: Vector[Keys] = pksAdded.rowsNeedingParentTasks
 
     if (rows.nonEmpty) {
       val table: Table = pksAdded.table

--- a/src/main/scala/trw/dbsubsetter/db/OriginDbAccess.scala
+++ b/src/main/scala/trw/dbsubsetter/db/OriginDbAccess.scala
@@ -1,7 +1,7 @@
 package trw.dbsubsetter.db
 
 trait OriginDbAccess {
-  def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: ForeignKeyValue): Vector[Row]
+  def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: ForeignKeyValue): Vector[Keys]
   def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[PrimaryKeyValue]): Vector[Row]
-  def getRows(query: SqlQuery, table: Table): Vector[Row]
+  def getRows(query: SqlQuery, table: Table): Vector[Keys]
 }

--- a/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverter.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverter.scala
@@ -2,8 +2,9 @@ package trw.dbsubsetter.db.impl.mapper
 
 import java.sql.ResultSet
 
-import trw.dbsubsetter.db.{Row, Table}
+import trw.dbsubsetter.db.{Keys, Row, Table}
 
 private[db] trait JdbcResultConverter {
-  def convert(res: ResultSet, table: Table): Vector[Row]
+  def convertToKeys(res: ResultSet, table: Table): Vector[Keys]
+  def convertToRows(res: ResultSet, table: Table): Vector[Row]
 }

--- a/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
@@ -2,13 +2,13 @@ package trw.dbsubsetter.db.impl.mapper
 
 import java.sql.ResultSet
 
-import trw.dbsubsetter.db.{Row, SchemaInfo, Table}
+import trw.dbsubsetter.db.{Keys, Row, SchemaInfo, Table}
 
 import scala.collection.mutable.ArrayBuffer
 
 private[db] class JdbcResultConverterImpl(schemaInfo: SchemaInfo) extends JdbcResultConverter {
 
-  def convert(res: ResultSet, table: Table): Vector[Row] = {
+  def convertToRows(res: ResultSet, table: Table): Vector[Row] = {
     val cols = schemaInfo.colsByTableOrdered(table).size
     val rows = ArrayBuffer.empty[Row]
     while (res.next()) {
@@ -19,4 +19,7 @@ private[db] class JdbcResultConverterImpl(schemaInfo: SchemaInfo) extends JdbcRe
     rows.toVector
   }
 
+  override def convertToKeys(res: ResultSet, table: Table): Vector[Keys] = {
+    ???
+  }
 }

--- a/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
@@ -8,18 +8,18 @@ import scala.collection.mutable.ArrayBuffer
 
 private[db] class JdbcResultConverterImpl(schemaInfo: SchemaInfo) extends JdbcResultConverter {
 
-  def convertToRows(res: ResultSet, table: Table): Vector[Row] = {
+  def convertToRows(jdbcResultSet: ResultSet, table: Table): Vector[Row] = {
     val cols = schemaInfo.colsByTableOrdered(table).size
     val rows = ArrayBuffer.empty[Row]
-    while (res.next()) {
+    while (jdbcResultSet.next()) {
       val row = new Row(cols)
-      (1 to cols).foreach(i => row(i - 1) = res.getObject(i))
+      (1 to cols).foreach(i => row(i - 1) = jdbcResultSet.getObject(i))
       rows += row
     }
     rows.toVector
   }
 
-  override def convertToKeys(res: ResultSet, table: Table): Vector[Keys] = {
-    ???
+  override def convertToKeys(jdbcResultSet: ResultSet, table: Table): Vector[Keys] = {
+    convertToRows(jdbcResultSet, table).map(data => new Keys(data))
   }
 }

--- a/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterTimed.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterTimed.scala
@@ -10,7 +10,7 @@ private[db] class JdbcResultConverterTimed(delegatee: JdbcResultConverter) exten
   private[this] val metrics = Metrics.JdbcResultConverterHistogram
 
   def convertToKeys(jdbcResultSet: ResultSet, table: Table): Vector[Keys] = {
-    metrics.time(() => delegatee.convertToRows(jdbcResultSet, table))
+    metrics.time(() => delegatee.convertToKeys(jdbcResultSet, table))
   }
 
   override def convertToRows(jdbcResultSet: ResultSet, table: Table): Vector[Row] = {

--- a/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterTimed.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterTimed.scala
@@ -2,15 +2,18 @@ package trw.dbsubsetter.db.impl.mapper
 
 import java.sql.ResultSet
 
-import trw.dbsubsetter.db.{Row, Table}
+import trw.dbsubsetter.db.{Keys, Row, Table}
 import trw.dbsubsetter.metrics.Metrics
 
 private[db] class JdbcResultConverterTimed(delegatee: JdbcResultConverter) extends JdbcResultConverter {
 
   private[this] val metrics = Metrics.JdbcResultConverterHistogram
 
-  def convert(jdbcResultSet: ResultSet, table: Table): Vector[Row] = {
-    metrics.time(() => delegatee.convert(jdbcResultSet, table))
+  def convertToKeys(jdbcResultSet: ResultSet, table: Table): Vector[Keys] = {
+    metrics.time(() => delegatee.convertToRows(jdbcResultSet, table))
   }
 
+  override def convertToRows(jdbcResultSet: ResultSet, table: Table): Vector[Row] = {
+    metrics.time(() => delegatee.convertToRows(jdbcResultSet, table))
+  }
 }

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/InstrumentedOriginDbAccess.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/InstrumentedOriginDbAccess.scala
@@ -2,7 +2,7 @@ package trw.dbsubsetter.db.impl.origin
 
 import io.prometheus.client.Histogram
 import io.prometheus.client.Histogram.Timer
-import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, OriginDbAccess, PrimaryKeyValue, Row, SqlQuery, Table}
+import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, Keys, OriginDbAccess, PrimaryKeyValue, Row, SqlQuery, Table}
 import trw.dbsubsetter.metrics.Metrics
 
 private[db] class InstrumentedOriginDbAccess(delegatee: OriginDbAccess) extends OriginDbAccess {
@@ -13,7 +13,7 @@ private[db] class InstrumentedOriginDbAccess(delegatee: OriginDbAccess) extends 
 
   private[this] val durationPerRow: Histogram = Metrics.OriginDbDurationPerRow
 
-  override def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: ForeignKeyValue): Vector[Row] = {
+  override def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: ForeignKeyValue): Vector[Keys] = {
     instrument(() => delegatee.getRowsFromForeignKeyValue(fk, table, fkValue))
   }
 
@@ -21,13 +21,13 @@ private[db] class InstrumentedOriginDbAccess(delegatee: OriginDbAccess) extends 
     delegatee.getRowsFromPrimaryKeyValues(table, primaryKeyValues)
   }
 
-  override def getRows(query: SqlQuery, table: Table): Vector[Row] = {
+  override def getRows(query: SqlQuery, table: Table): Vector[Keys] = {
     instrument(() => delegatee.getRows(query, table))
   }
 
-  private[this] def instrument(func: () => Vector[Row]): Vector[Row] = {
+  private[this] def instrument(func: () => Vector[Keys]): Vector[Keys] = {
     val timer: Timer = durationPerStatement.startTimer()
-    val result: Vector[Row] = func.apply()
+    val result: Vector[Keys] = func.apply()
     val statementDuration: Double = timer.observeDuration()
     rowsFetchedPerStatement.observe(result.length)
     if (result.nonEmpty) { // TODO test the divide by zero case

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -4,7 +4,7 @@ import java.sql.PreparedStatement
 
 import trw.dbsubsetter.db.impl.connection.ConnectionFactory
 import trw.dbsubsetter.db.impl.mapper.JdbcResultConverter
-import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, OriginDbAccess, PrimaryKeyValue, Row, SchemaInfo, Sql, SqlQuery, Table}
+import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, Keys, OriginDbAccess, PrimaryKeyValue, Row, SchemaInfo, Sql, SqlQuery, Table}
 
 
 // TODO fix this so the line is shorter and re-enable scalastyle
@@ -24,7 +24,7 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
       tableWithBatchSize -> conn.prepareStatement(sqlString)
     }
 
-  override def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: ForeignKeyValue): Vector[Row] = {
+  override def getRowsFromForeignKeyValue(fk: ForeignKey, table: Table, fkValue: ForeignKeyValue): Vector[Keys] = {
     val stmt = foreignKeyTemplateStatements(fk, table)
     stmt.clearParameters()
 
@@ -33,7 +33,7 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
     }
 
     val jdbcResult = stmt.executeQuery()
-    mapper.convert(jdbcResult, table)
+    mapper.convertToKeys(jdbcResult, table)
   }
 
   override def getRowsFromPrimaryKeyValues(table: Table, primaryKeyValues: Seq[PrimaryKeyValue]): Vector[Row] = {
@@ -49,11 +49,11 @@ private[db] class OriginDbAccessImpl(connStr: String, sch: SchemaInfo, mapper: J
     }
 
     val jdbcResult = stmt.executeQuery()
-    mapper.convert(jdbcResult, table)
+    mapper.convertToRows(jdbcResult, table)
   }
 
-  override def getRows(query: SqlQuery, table: Table): Vector[Row] = {
+  override def getRows(query: SqlQuery, table: Table): Vector[Keys] = {
     val jdbcResult = conn.createStatement().executeQuery(query)
-    mapper.convert(jdbcResult, table)
+    mapper.convertToKeys(jdbcResult, table)
   }
 }

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -61,6 +61,17 @@ package object db {
     val isEmpty: Boolean = individualColumnValues.forall(_ == null)
   }
 
+  // Represents a single row in the origin database including only primary and foreign key columns
+  class Keys(data: Array[Any]) {
+    def getValue(primaryKey: PrimaryKey): PrimaryKeyValue = {
+      ???
+    }
+
+    def getValue(foreignKey: ForeignKey): ForeignKeyValue = {
+      ???
+    }
+  }
+
   implicit class VendorAwareJdbcConnection(private val conn: Connection) {
     private val vendorName: String = conn.getMetaData.getDatabaseProductName
 

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -62,15 +62,7 @@ package object db {
   }
 
   // Represents a single row in the origin database including only primary and foreign key columns
-  class Keys(data: Array[Any]) {
-    def getValue(primaryKey: PrimaryKey): PrimaryKeyValue = {
-      ???
-    }
-
-    def getValue(foreignKey: ForeignKey): ForeignKeyValue = {
-      ???
-    }
-  }
+  class Keys(val data: Array[Any])
 
   implicit class VendorAwareJdbcConnection(private val conn: Connection) {
     private val vendorName: String = conn.getMetaData.getDatabaseProductName

--- a/src/main/scala/trw/dbsubsetter/keyextraction/KeyExtractionUtil.scala
+++ b/src/main/scala/trw/dbsubsetter/keyextraction/KeyExtractionUtil.scala
@@ -7,8 +7,8 @@ object KeyExtractionUtil {
   def pkExtractionFunctions(schemaInfo: SchemaInfo): Map[Table, Keys => PrimaryKeyValue] = {
     schemaInfo.pksByTable.map { case (table, primaryKey) =>
       val primaryKeyColumnOrdinals: Seq[Int] = primaryKey.columns.map(_.ordinalPosition)
-      val primaryKeyExtractionFunction: Keys => PrimaryKeyValue = row => {
-        val individualColumnValues: Seq[Any] = primaryKeyColumnOrdinals.map(row)
+      val primaryKeyExtractionFunction: Keys => PrimaryKeyValue = keys => {
+        val individualColumnValues: Seq[Any] = primaryKeyColumnOrdinals.map(keys.data)
         new PrimaryKeyValue(individualColumnValues)
       }
       table -> primaryKeyExtractionFunction
@@ -21,12 +21,12 @@ object KeyExtractionUtil {
       val parentExtractionOrdinalPositions =
         foreignKey.fromCols.map(_.ordinalPosition)
       val parentExtractionFunction: Keys => ForeignKeyValue =
-        row => new ForeignKeyValue(parentExtractionOrdinalPositions.map(row))
+        keys => new ForeignKeyValue(parentExtractionOrdinalPositions.map(keys.data))
 
       val childExtractionOrdinalPositions =
         foreignKey.toCols.map(_.ordinalPosition)
       val childExtractionFunction: Keys => ForeignKeyValue =
-        row => new ForeignKeyValue(childExtractionOrdinalPositions.map(row))
+        keys => new ForeignKeyValue(childExtractionOrdinalPositions.map(keys.data))
 
       Seq(
         (foreignKey, false) -> parentExtractionFunction,

--- a/src/main/scala/trw/dbsubsetter/keyextraction/KeyExtractionUtil.scala
+++ b/src/main/scala/trw/dbsubsetter/keyextraction/KeyExtractionUtil.scala
@@ -1,13 +1,13 @@
 package trw.dbsubsetter.keyextraction
 
-import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, PrimaryKeyValue, Row, SchemaInfo, Table}
+import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, Keys, PrimaryKeyValue, SchemaInfo, Table}
 
 object KeyExtractionUtil {
 
-  def pkExtractionFunctions(schemaInfo: SchemaInfo): Map[Table, Row => PrimaryKeyValue] = {
+  def pkExtractionFunctions(schemaInfo: SchemaInfo): Map[Table, Keys => PrimaryKeyValue] = {
     schemaInfo.pksByTable.map { case (table, primaryKey) =>
       val primaryKeyColumnOrdinals: Seq[Int] = primaryKey.columns.map(_.ordinalPosition)
-      val primaryKeyExtractionFunction: Row => PrimaryKeyValue = row => {
+      val primaryKeyExtractionFunction: Keys => PrimaryKeyValue = row => {
         val individualColumnValues: Seq[Any] = primaryKeyColumnOrdinals.map(row)
         new PrimaryKeyValue(individualColumnValues)
       }
@@ -15,17 +15,17 @@ object KeyExtractionUtil {
     }
   }
 
-  def fkExtractionFunctions(schemaInfo: SchemaInfo): Map[(ForeignKey, Boolean), Row => ForeignKeyValue] = {
+  def fkExtractionFunctions(schemaInfo: SchemaInfo): Map[(ForeignKey, Boolean), Keys => ForeignKeyValue] = {
     schemaInfo.fksOrdered.flatMap { foreignKey =>
 
       val parentExtractionOrdinalPositions =
         foreignKey.fromCols.map(_.ordinalPosition)
-      val parentExtractionFunction: Row => ForeignKeyValue =
+      val parentExtractionFunction: Keys => ForeignKeyValue =
         row => new ForeignKeyValue(parentExtractionOrdinalPositions.map(row))
 
       val childExtractionOrdinalPositions =
         foreignKey.toCols.map(_.ordinalPosition)
-      val childExtractionFunction: Row => ForeignKeyValue =
+      val childExtractionFunction: Keys => ForeignKeyValue =
         row => new ForeignKeyValue(childExtractionOrdinalPositions.map(row))
 
       Seq(

--- a/src/main/scala/trw/dbsubsetter/workflow/FkTaskCreationWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/FkTaskCreationWorkflow.scala
@@ -8,7 +8,7 @@ import trw.dbsubsetter.keyextraction.KeyExtractionUtil
 // TODO do the same reconsideration for the Akka Streams Flow that calls this.
 final class FkTaskCreationWorkflow(schemaInfo: SchemaInfo) {
 
-  private[this] val fkExtractionFunctions: Map[(ForeignKey, Boolean), Row => ForeignKeyValue] =
+  private[this] val fkExtractionFunctions: Map[(ForeignKey, Boolean), Keys => ForeignKeyValue] =
     KeyExtractionUtil.fkExtractionFunctions(schemaInfo)
 
   def createFkTasks(pksAdded: PksAdded): NewTasks = {
@@ -18,7 +18,7 @@ final class FkTaskCreationWorkflow(schemaInfo: SchemaInfo) {
     NewTasks(parentTasks.taskInfo ++ childTasks.taskInfo)
   }
 
-  private[this] def calcParentTasks(table: Table, rows: Vector[Row], viaTableOpt: Option[Table]): NewTasks = {
+  private[this] def calcParentTasks(table: Table, rows: Vector[Keys], viaTableOpt: Option[Table]): NewTasks = {
     // Re: `viaTableOpt`
     // If we know that the reason we fetched a row to begin with is that it is the child of some row we've
     // already fetched, then we know that we don't need to go fetch that particular parent row again
@@ -29,17 +29,17 @@ final class FkTaskCreationWorkflow(schemaInfo: SchemaInfo) {
     val useForeignKeys = viaTableOpt.fold(allForeignKeys)(viaTable => allForeignKeys.filterNot(fk => fk.toTable == viaTable))
     val newTasksInfo: Map[(ForeignKey, Boolean), Seq[ForeignKeyValue]] =
       useForeignKeys.map { fk =>
-        val fkValueExtractionFunction: Row => ForeignKeyValue = fkExtractionFunctions(fk, false)
+        val fkValueExtractionFunction: Keys => ForeignKeyValue = fkExtractionFunctions(fk, false)
         val fkValues: Seq[ForeignKeyValue] = rows.map(fkValueExtractionFunction).filterNot(_.isEmpty)
         (fk, false) -> fkValues
       }.toMap
     NewTasks(newTasksInfo)
   }
 
-  private[this] def calcChildTasks(table: Table, rows: Vector[Row]): NewTasks = {
+  private[this] def calcChildTasks(table: Table, rows: Vector[Keys]): NewTasks = {
     val allForeignKeys = schemaInfo.fksToTable(table)
     val newTasksInfo: Map[(ForeignKey, Boolean), Seq[ForeignKeyValue]] = allForeignKeys.map { fk =>
-      val fkValueExtractionFunction: Row => ForeignKeyValue = fkExtractionFunctions(fk, true)
+      val fkValueExtractionFunction: Keys => ForeignKeyValue = fkExtractionFunctions(fk, true)
       val fkValues: Seq[ForeignKeyValue] = rows.map(fkValueExtractionFunction)
       (fk, true) -> fkValues
     }.toMap

--- a/src/main/scala/trw/dbsubsetter/workflow/package.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/package.scala
@@ -12,9 +12,9 @@ package object workflow {
   case class FetchParentTask(parentTable: Table, fk: ForeignKey, fkValueFromChild: ForeignKeyValue) extends ForeignKeyTask
   case class FetchChildrenTask(childTable: Table, viaParentTable: Table, fk: ForeignKey, fkValueFromParent: ForeignKeyValue) extends ForeignKeyTask
 
-  case class OriginDbResult(table: Table, rows: Vector[Row], viaTableOpt: Option[Table], fetchChildren: Boolean)
+  case class OriginDbResult(table: Table, rows: Vector[Keys], viaTableOpt: Option[Table], fetchChildren: Boolean)
 
-  case class PksAdded(table: Table, rowsNeedingParentTasks: Vector[Row], rowsNeedingChildTasks: Vector[Row], viaTableOpt: Option[Table])
+  case class PksAdded(table: Table, rowsNeedingParentTasks: Vector[Keys], rowsNeedingChildTasks: Vector[Keys], viaTableOpt: Option[Table])
 
   class DataCopyTask(val table: Table, val pkValues: Seq[PrimaryKeyValue])
 

--- a/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
+++ b/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
@@ -8,7 +8,7 @@ import org.postgresql.copy.CopyManager
 import org.postgresql.core.BaseConnection
 import slick.jdbc.PostgresProfile.api._
 import slick.sql.SqlAction
-import trw.dbsubsetter.db.Keys
+import trw.dbsubsetter.db.Row
 import util.db.{DatabaseSet, PostgreSQLDatabase}
 
 import scala.collection.mutable.ArrayBuffer
@@ -177,7 +177,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
       targetJdbcConnection.prepareStatement(insertSql)
     }
 
-    def insertRows(insertStatement: PreparedStatement, rows: Vector[Keys]): Unit = {
+    def insertRows(insertStatement: PreparedStatement, rows: Vector[Row]): Unit = {
       insertStatement.clearParameters()
 
       rows.foreach { row =>
@@ -198,7 +198,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
     val insertStatement: PreparedStatement = buildInsertStatement(tableSuffix)
     val runtimeSeconds: Long = runWithTimerSeconds(() => {
       (1 to 6000000 by batchSize).foreach(startOfBatchId => {
-        val rows: Vector[Keys] = fetchRows(startOfBatchId, startOfBatchId + batchSize - 1)
+        val rows: Vector[Row] = fetchRows(startOfBatchId, startOfBatchId + batchSize - 1)
         insertRows(insertStatement, rows)
       })
     })
@@ -217,7 +217,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
       targetJdbcConnection.prepareStatement(insertSql)
     }
 
-    def insertRows(insertStatement: PreparedStatement, rows: Vector[Keys]): Unit = {
+    def insertRows(insertStatement: PreparedStatement, rows: Vector[Row]): Unit = {
       insertStatement.clearParameters()
 
       rows.zipWithIndex.foreach { case (row, rowIndex) =>
@@ -237,7 +237,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
     val defaultInsertStatement: PreparedStatement = buildInsertStatement(batchSize)
     val runtimeSeconds: Long = runWithTimerSeconds(() => {
       (1 to 6000000 by batchSize).foreach(startOfBatchId => {
-        val rows: Vector[Keys] = fetchRows(startOfBatchId, startOfBatchId + batchSize - 1)
+        val rows: Vector[Row] = fetchRows(startOfBatchId, startOfBatchId + batchSize - 1)
         val insertStatement: PreparedStatement =
           if (rows.length == batchSize) {
             defaultInsertStatement
@@ -315,15 +315,15 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
     originJdbcConnection.prepareStatement("select * from quantum_data where id between ? and ?")
   }
 
-  private[this] def fetchRows(start: Int, end: Int): Vector[Keys] = {
+  private[this] def fetchRows(start: Int, end: Int): Vector[Row] = {
     selectStatement.clearParameters()
     selectStatement.setObject(1, start)
     selectStatement.setObject(2, end)
     val resultSet: ResultSet = selectStatement.executeQuery()
 
-    val rows = ArrayBuffer.empty[Keys]
+    val rows = ArrayBuffer.empty[Row]
     while (resultSet.next()) {
-      val row: Keys = Array(
+      val row: Row = Array(
         resultSet.getObject(1),
         resultSet.getObject(2),
         resultSet.getObject(3),

--- a/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
+++ b/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
@@ -8,7 +8,7 @@ import org.postgresql.copy.CopyManager
 import org.postgresql.core.BaseConnection
 import slick.jdbc.PostgresProfile.api._
 import slick.sql.SqlAction
-import trw.dbsubsetter.db.Row
+import trw.dbsubsetter.db.Keys
 import util.db.{DatabaseSet, PostgreSQLDatabase}
 
 import scala.collection.mutable.ArrayBuffer
@@ -177,7 +177,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
       targetJdbcConnection.prepareStatement(insertSql)
     }
 
-    def insertRows(insertStatement: PreparedStatement, rows: Vector[Row]): Unit = {
+    def insertRows(insertStatement: PreparedStatement, rows: Vector[Keys]): Unit = {
       insertStatement.clearParameters()
 
       rows.foreach { row =>
@@ -198,7 +198,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
     val insertStatement: PreparedStatement = buildInsertStatement(tableSuffix)
     val runtimeSeconds: Long = runWithTimerSeconds(() => {
       (1 to 6000000 by batchSize).foreach(startOfBatchId => {
-        val rows: Vector[Row] = fetchRows(startOfBatchId, startOfBatchId + batchSize - 1)
+        val rows: Vector[Keys] = fetchRows(startOfBatchId, startOfBatchId + batchSize - 1)
         insertRows(insertStatement, rows)
       })
     })
@@ -217,7 +217,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
       targetJdbcConnection.prepareStatement(insertSql)
     }
 
-    def insertRows(insertStatement: PreparedStatement, rows: Vector[Row]): Unit = {
+    def insertRows(insertStatement: PreparedStatement, rows: Vector[Keys]): Unit = {
       insertStatement.clearParameters()
 
       rows.zipWithIndex.foreach { case (row, rowIndex) =>
@@ -237,7 +237,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
     val defaultInsertStatement: PreparedStatement = buildInsertStatement(batchSize)
     val runtimeSeconds: Long = runWithTimerSeconds(() => {
       (1 to 6000000 by batchSize).foreach(startOfBatchId => {
-        val rows: Vector[Row] = fetchRows(startOfBatchId, startOfBatchId + batchSize - 1)
+        val rows: Vector[Keys] = fetchRows(startOfBatchId, startOfBatchId + batchSize - 1)
         val insertStatement: PreparedStatement =
           if (rows.length == batchSize) {
             defaultInsertStatement
@@ -315,15 +315,15 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
     originJdbcConnection.prepareStatement("select * from quantum_data where id between ? and ?")
   }
 
-  private[this] def fetchRows(start: Int, end: Int): Vector[Row] = {
+  private[this] def fetchRows(start: Int, end: Int): Vector[Keys] = {
     selectStatement.clearParameters()
     selectStatement.setObject(1, start)
     selectStatement.setObject(2, end)
     val resultSet: ResultSet = selectStatement.executeQuery()
 
-    val rows = ArrayBuffer.empty[Row]
+    val rows = ArrayBuffer.empty[Keys]
     while (resultSet.next()) {
-      val row: Row = Array(
+      val row: Keys = Array(
         resultSet.getObject(1),
         resultSet.getObject(2),
         resultSet.getObject(3),

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -2,7 +2,7 @@ package unit
 
 import org.scalatest.FunSuite
 import trw.dbsubsetter.config.Config
-import trw.dbsubsetter.db.{Column, PrimaryKey, PrimaryKeyValue, Row, SchemaInfo, Table}
+import trw.dbsubsetter.db.{Column, Keys, PrimaryKey, PrimaryKeyValue, SchemaInfo, Table}
 import trw.dbsubsetter.primarykeystore.{PrimaryKeyStore, PrimaryKeyStoreFactory}
 import trw.dbsubsetter.workflow._
 
@@ -41,9 +41,9 @@ class PkStoreWorkflowTest extends FunSuite {
 
     val fkValue: String = "fkValue"
 
-    val row: Row = Array(fkValue)
+    val row: Keys = Array(fkValue)
 
-    val rows: Vector[Row] = Vector(row)
+    val rows: Vector[Keys] = Vector(row)
 
     val correspondingPrimaryKeyValue: PrimaryKeyValue = new PrimaryKeyValue(Seq(fkValue))
 
@@ -104,8 +104,8 @@ class PkStoreWorkflowTest extends FunSuite {
       new PkStoreWorkflow(pkStore, schemaInfo)
 
     val fkValue: String = "fkValue"
-    val row: Row = Array(fkValue)
-    val rows: Vector[Row] = Vector(row)
+    val row: Keys = Array(fkValue)
+    val rows: Vector[Keys] = Vector(row)
 
     // Add the PK to the pkStore, noting that we have NOT yet fetched children
     val pkAddRequest1 = OriginDbResult(table, rows, viaTableOpt = None, fetchChildren = true)

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -41,16 +41,16 @@ class PkStoreWorkflowTest extends FunSuite {
 
     val fkValue: String = "fkValue"
 
-    val row: Keys = Array(fkValue)
+    val singleRowKeys: Keys = new Keys(Array(fkValue))
 
-    val rows: Vector[Keys] = Vector(row)
+    val multiRowKeys: Vector[Keys] = Vector(singleRowKeys)
 
     val correspondingPrimaryKeyValue: PrimaryKeyValue = new PrimaryKeyValue(Seq(fkValue))
 
     // Add the PK to the pkStore, noting that we have NOT yet fetched children
-    val pkAddRequest1 = OriginDbResult(table, rows, None, fetchChildren = false)
+    val pkAddRequest1 = OriginDbResult(table, multiRowKeys, None, fetchChildren = false)
     val pkAddResult1 = pkStoreWorkflow.add(pkAddRequest1)
-    assert(pkAddResult1 === PksAdded(table, rows, Vector.empty, None))
+    assert(pkAddResult1 === PksAdded(table, multiRowKeys, Vector.empty, None))
 
     // Query whether the PK is in the pkStore given that we are only interested in parent records
     // The return value should be true, meaning that yes it's in the pkStore at least as far as having fetched its parent records
@@ -60,9 +60,9 @@ class PkStoreWorkflowTest extends FunSuite {
     // The fact that it was already in the PK store for having its parents fetched means that
     // It will only appear in the collection of rows still needing children processing
     // It will not appear in the collection of rows needing parents (and therefore will not be added duplicate to the target db either)
-    val pkAddRequest2 = OriginDbResult(table, rows, None, fetchChildren = true)
+    val pkAddRequest2 = OriginDbResult(table, multiRowKeys, None, fetchChildren = true)
     val pkAddResult2 = pkStoreWorkflow.add(pkAddRequest2)
-    assert(pkAddResult2 === PksAdded(table, Vector.empty, rows, None))
+    assert(pkAddResult2 === PksAdded(table, Vector.empty, multiRowKeys, None))
 
     // Do the same query as before
     // Query whether the PK is in the pkStore given that we are only interested in parent records
@@ -104,16 +104,16 @@ class PkStoreWorkflowTest extends FunSuite {
       new PkStoreWorkflow(pkStore, schemaInfo)
 
     val fkValue: String = "fkValue"
-    val row: Keys = Array(fkValue)
-    val rows: Vector[Keys] = Vector(row)
+    val singleRowKeys: Keys = new Keys(Array(fkValue))
+    val multiRowKeys: Vector[Keys] = Vector(singleRowKeys)
 
     // Add the PK to the pkStore, noting that we have NOT yet fetched children
-    val pkAddRequest1 = OriginDbResult(table, rows, viaTableOpt = None, fetchChildren = true)
+    val pkAddRequest1 = OriginDbResult(table, multiRowKeys, viaTableOpt = None, fetchChildren = true)
     val actual = pkStoreWorkflow.add(pkAddRequest1)
     val expected: PksAdded = PksAdded(
       table = table,
-      rowsNeedingParentTasks = rows,
-      rowsNeedingChildTasks = rows,
+      rowsNeedingParentTasks = multiRowKeys,
+      rowsNeedingChildTasks = multiRowKeys,
       viaTableOpt = None
     )
     assert(actual === expected)


### PR DESCRIPTION
Create different types representing

1) A row fetched from the origin database with all columns included: `Row`
2) A row fetched from the origin database with only primary and foreign key columns included: `Keys`

Right now, the two types under the hood still contain data from all columns. But that's just a temporary situation. The end goal is that `Keys` under the hood should only hold key data. By first separating out these types, it should become easier to reach the desired end state.