### PR TITLE
Further increase type safety of keys

### DIFF
--- a/src/main/scala/trw/dbsubsetter/db/BaseQueries.scala
+++ b/src/main/scala/trw/dbsubsetter/db/BaseQueries.scala
@@ -7,7 +7,8 @@ object BaseQueries {
   def get(config: Config, sch: SchemaInfo): Vector[BaseQuery] = {
     config.baseQueries.map { case ((schemaName, tableName), whereClause, fetchChildren) =>
       val table = sch.tablesByName((schemaName, tableName))
-      val sqlString = Sql.makeQueryString(table, whereClause, sch)
+      val selectColumns = sch.keyColumnsByTableOrdered(table)
+      val sqlString = Sql.makeQueryString(table, selectColumns, whereClause, sch)
       BaseQuery(table, sqlString, fetchChildren)
     }
   }

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -21,7 +21,7 @@ object SchemaInfoRetrieval {
         .map { case (table, cols) =>
           table -> cols.zipWithIndex.map { case (c, i) =>
             val columnType: ColumnType = ColumnTypes.fromRawInfo(c.jdbcType, c.typeName, dbVendor)
-            c.name -> new Column(table, c.name, i, columnType)
+            c.name -> new Column(table, c.name, i, i, columnType)
           }.toMap
         }
     }

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -90,12 +90,13 @@ object SchemaInfoRetrieval {
     }
 
     new SchemaInfo(
-      tablesByName,
-      colsByTableOrdered,
-      pksByTable,
-      foreignKeysOrdered,
-      fksFromTable,
-      fksToTable
+      tablesByName = tablesByName,
+      keyColumnsByTableOrdered = colsByTableOrdered, // TODO replace this with just the key columns
+      dataColumnsByTableOrdered = colsByTableOrdered,
+      pksByTable = pksByTable,
+      fksOrdered = foreignKeysOrdered,
+      fksFromTable = fksFromTable,
+      fksToTable = fksToTable
     )
   }
 }

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -21,12 +21,19 @@ object SchemaInfoRetrieval {
         .map { case (table, cols) =>
           table -> cols.zipWithIndex.map { case (c, i) =>
             val columnType: ColumnType = ColumnTypes.fromRawInfo(c.jdbcType, c.typeName, dbVendor)
-            c.name -> new Column(table, c.name, i, i, columnType)
+            val column: Column = new Column(
+              table = table,
+              name = c.name,
+              keyOrdinalPosition = i, // TODO separate keyOrdinalPosition from dataOrdinalPosition
+              dataOrdinalPosition = i,
+              dataType = columnType
+            )
+            c.name -> column
           }.toMap
         }
     }
 
-    val colsByTableOrdered: Map[Table, Vector[Column]] = {
+    val allColumnsByTableOrdered: Map[Table, Vector[Column]] = {
       colsByTableAndName.map { case (table, map) => table -> map.values.toVector.sortBy(_.dataOrdinalPosition) }
     }
 
@@ -35,7 +42,7 @@ object SchemaInfoRetrieval {
         .groupBy(pk => tablesByName(pk.schema, pk.table))
         .map { case (table, singleTablePrimaryKeyMetadataRows) =>
           val columnNames = singleTablePrimaryKeyMetadataRows.map(_.column).toSet
-          val orderedColumns = colsByTableOrdered(table).filter(c => columnNames.contains(c.name))
+          val orderedColumns = allColumnsByTableOrdered(table).filter(c => columnNames.contains(c.name))
           table -> new PrimaryKey(orderedColumns)
         }
     }
@@ -91,8 +98,8 @@ object SchemaInfoRetrieval {
 
     new SchemaInfo(
       tablesByName = tablesByName,
-      keyColumnsByTableOrdered = colsByTableOrdered, // TODO replace this with just the key columns
-      dataColumnsByTableOrdered = colsByTableOrdered,
+      keyColumnsByTableOrdered = allColumnsByTableOrdered, // TODO replace this with just the key columns
+      dataColumnsByTableOrdered = allColumnsByTableOrdered,
       pksByTable = pksByTable,
       fksOrdered = foreignKeysOrdered,
       fksFromTable = fksFromTable,

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -27,7 +27,7 @@ object SchemaInfoRetrieval {
     }
 
     val colsByTableOrdered: Map[Table, Vector[Column]] = {
-      colsByTableAndName.map { case (table, map) => table -> map.values.toVector.sortBy(_.ordinalPosition) }
+      colsByTableAndName.map { case (table, map) => table -> map.values.toVector.sortBy(_.dataOrdinalPosition) }
     }
 
     val pksByTable: Map[Table, PrimaryKey] = {

--- a/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable.ArrayBuffer
 private[db] class JdbcResultConverterImpl(schemaInfo: SchemaInfo) extends JdbcResultConverter {
 
   def convertToRows(jdbcResultSet: ResultSet, table: Table): Vector[Row] = {
-    val cols = schemaInfo.colsByTableOrdered(table).size
+    val cols = schemaInfo.dataColumnsByTableOrdered(table).size
     val rows = ArrayBuffer.empty[Row]
     while (jdbcResultSet.next()) {
       val row = new Row(cols)

--- a/src/main/scala/trw/dbsubsetter/db/impl/target/TargetDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/target/TargetDbAccessImpl.scala
@@ -17,7 +17,7 @@ private[db] class TargetDbAccessImpl(connStr: String, sch: SchemaInfo, connectio
   override def insertRows(table: Table, rows: Vector[Row]): Unit = {
 
     val stmt = statements(table)
-    val cols = sch.colsByTableOrdered(table).size
+    val cols = sch.dataColumnsByTableOrdered(table).size
 
     rows.foreach { row =>
       (1 to cols).foreach(i => stmt.setObject(i, row(i - 1)))

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -33,7 +33,10 @@ package object db {
   class Column(
     val table: Table,
     val name: ColumnName,
-    // The 0-indexed location of this column in query results where only primary and foreign key columns are included
+    /*
+     * The 0-indexed location of this column in query results where only primary and foreign key columns are included
+     * -1 if this column is not part of a primary or foreign key, as this column would not be included in that query
+     */
     val keyOrdinalPosition: Int,
     // The 0-indexed location of this column in query results where all columns are included
     val dataOrdinalPosition: Int,

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -67,9 +67,7 @@ package object db {
   // Represents a single row from the origin database including only primary and foreign key columns
   class Keys(data: Array[Any]) {
     def getValue(pk: PrimaryKey): PrimaryKeyValue = {
-      val individualColumnValues: Seq[Any] =
-        pk.columns.map(_.keyOrdinalPosition).map(data)
-
+      val individualColumnValues: Seq[Any] = pk.columns.map(_.keyOrdinalPosition).map(data)
       new PrimaryKeyValue(individualColumnValues)
     }
 

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -64,7 +64,7 @@ package object db {
     val isEmpty: Boolean = individualColumnValues.forall(_ == null)
   }
 
-  // Represents a single row in the origin database including only primary and foreign key columns
+  // Represents a single row from the origin database including only primary and foreign key columns
   class Keys(data: Array[Any]) {
     def getValue(pk: PrimaryKey): PrimaryKeyValue = {
       val individualColumnValues: Seq[Any] =

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -17,7 +17,10 @@ package object db {
 
   class SchemaInfo(
     val tablesByName: Map[(SchemaName, TableName), Table],
-    val colsByTableOrdered: Map[Table, Vector[Column]],
+    // Only those columns involved in a primary or foreign key
+    val keyColumnsByTableOrdered: Map[Table, Vector[Column]],
+    // All columns, even those uninvolved in a primary or foreign key
+    val dataColumnsByTableOrdered: Map[Table, Vector[Column]],
     val pksByTable: Map[Table, PrimaryKey],
     val fksOrdered: Array[ForeignKey],
     val fksFromTable: Map[Table, Vector[ForeignKey]],

--- a/src/main/scala/trw/dbsubsetter/keyextraction/KeyExtractionUtil.scala
+++ b/src/main/scala/trw/dbsubsetter/keyextraction/KeyExtractionUtil.scala
@@ -6,11 +6,7 @@ object KeyExtractionUtil {
 
   def pkExtractionFunctions(schemaInfo: SchemaInfo): Map[Table, Keys => PrimaryKeyValue] = {
     schemaInfo.pksByTable.map { case (table, primaryKey) =>
-      val primaryKeyColumnOrdinals: Seq[Int] = primaryKey.columns.map(_.ordinalPosition)
-      val primaryKeyExtractionFunction: Keys => PrimaryKeyValue = keys => {
-        val individualColumnValues: Seq[Any] = primaryKeyColumnOrdinals.map(keys.data)
-        new PrimaryKeyValue(individualColumnValues)
-      }
+      val primaryKeyExtractionFunction: Keys => PrimaryKeyValue = keys => keys.getValue(primaryKey)
       table -> primaryKeyExtractionFunction
     }
   }
@@ -18,15 +14,11 @@ object KeyExtractionUtil {
   def fkExtractionFunctions(schemaInfo: SchemaInfo): Map[(ForeignKey, Boolean), Keys => ForeignKeyValue] = {
     schemaInfo.fksOrdered.flatMap { foreignKey =>
 
-      val parentExtractionOrdinalPositions =
-        foreignKey.fromCols.map(_.ordinalPosition)
       val parentExtractionFunction: Keys => ForeignKeyValue =
-        keys => new ForeignKeyValue(parentExtractionOrdinalPositions.map(keys.data))
+        keys => keys.getValue(foreignKey, confusingTechDebt = false)
 
-      val childExtractionOrdinalPositions =
-        foreignKey.toCols.map(_.ordinalPosition)
       val childExtractionFunction: Keys => ForeignKeyValue =
-        keys => new ForeignKeyValue(childExtractionOrdinalPositions.map(keys.data))
+        keys => keys.getValue(foreignKey, confusingTechDebt = true)
 
       Seq(
         (foreignKey, false) -> parentExtractionFunction,

--- a/src/test/scala/integration/OffHeapTaskQueueTest.scala
+++ b/src/test/scala/integration/OffHeapTaskQueueTest.scala
@@ -115,7 +115,8 @@ private[this] object OffHeapTaskQueueTest {
   private val schemaInfo: SchemaInfo =
     new SchemaInfo(
       tablesByName = Map.empty,
-      colsByTableOrdered = Map.empty,
+      keyColumnsByTableOrdered = Map.empty,
+      dataColumnsByTableOrdered = Map.empty,
       pksByTable = Map.empty,
       fksOrdered = Array(foreignKey),
       fksFromTable = Map.empty,

--- a/src/test/scala/integration/OffHeapTaskQueueTest.scala
+++ b/src/test/scala/integration/OffHeapTaskQueueTest.scala
@@ -83,7 +83,7 @@ private[this] object OffHeapTaskQueueTest {
     new Column(
       table = parentTable,
       name = "id",
-      ordinalPosition = 4,
+      dataOrdinalPosition = 4,
       ColumnTypes.Long
     )
 
@@ -98,7 +98,7 @@ private[this] object OffHeapTaskQueueTest {
     new Column(
       table = childTable,
       name = "parentId",
-      ordinalPosition = 7,
+      dataOrdinalPosition = 7,
       ColumnTypes.Long
     )
 

--- a/src/test/scala/integration/OffHeapTaskQueueTest.scala
+++ b/src/test/scala/integration/OffHeapTaskQueueTest.scala
@@ -84,7 +84,7 @@ private[this] object OffHeapTaskQueueTest {
       table = parentTable,
       name = "id",
       keyOrdinalPosition = 4,
-      dataOrdinalPosition = 4,
+      dataOrdinalPosition = -1, // n/a
       ColumnTypes.Long
     )
 
@@ -100,7 +100,7 @@ private[this] object OffHeapTaskQueueTest {
       table = childTable,
       name = "parentId",
       keyOrdinalPosition = 7,
-      dataOrdinalPosition = 7,
+      dataOrdinalPosition = -1, // n/a
       ColumnTypes.Long
     )
 

--- a/src/test/scala/integration/OffHeapTaskQueueTest.scala
+++ b/src/test/scala/integration/OffHeapTaskQueueTest.scala
@@ -83,6 +83,7 @@ private[this] object OffHeapTaskQueueTest {
     new Column(
       table = parentTable,
       name = "id",
+      keyOrdinalPosition = 4,
       dataOrdinalPosition = 4,
       ColumnTypes.Long
     )
@@ -98,6 +99,7 @@ private[this] object OffHeapTaskQueueTest {
     new Column(
       table = childTable,
       name = "parentId",
+      keyOrdinalPosition = 7,
       dataOrdinalPosition = 7,
       ColumnTypes.Long
     )

--- a/src/test/scala/unit/PkStoreTest.scala
+++ b/src/test/scala/unit/PkStoreTest.scala
@@ -18,6 +18,7 @@ class PkStoreTest extends FunSuite {
       new Column(
         table = table,
         name = null,
+        keyOrdinalPosition = 0,
         dataOrdinalPosition = 0,
         dataType = null
       )

--- a/src/test/scala/unit/PkStoreTest.scala
+++ b/src/test/scala/unit/PkStoreTest.scala
@@ -26,7 +26,8 @@ class PkStoreTest extends FunSuite {
     val schemaInfo: SchemaInfo =
       new SchemaInfo(
         tablesByName = Map.empty,
-        colsByTableOrdered = Map.empty,
+        keyColumnsByTableOrdered = Map.empty,
+        dataColumnsByTableOrdered = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(pkCol))),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,

--- a/src/test/scala/unit/PkStoreTest.scala
+++ b/src/test/scala/unit/PkStoreTest.scala
@@ -19,7 +19,7 @@ class PkStoreTest extends FunSuite {
         table = table,
         name = null,
         keyOrdinalPosition = 0,
-        dataOrdinalPosition = 0,
+        dataOrdinalPosition = -1, // n/a
         dataType = null
       )
 

--- a/src/test/scala/unit/PkStoreTest.scala
+++ b/src/test/scala/unit/PkStoreTest.scala
@@ -18,7 +18,7 @@ class PkStoreTest extends FunSuite {
       new Column(
         table = table,
         name = null,
-        ordinalPosition = 0,
+        dataOrdinalPosition = 0,
         dataType = null
       )
 

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -27,7 +27,8 @@ class PkStoreWorkflowTest extends FunSuite {
     val schemaInfo: SchemaInfo =
       new SchemaInfo(
         tablesByName = Map.empty,
-        colsByTableOrdered = Map.empty,
+        keyColumnsByTableOrdered = Map.empty,
+        dataColumnsByTableOrdered = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(pkCol))),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,
@@ -92,7 +93,8 @@ class PkStoreWorkflowTest extends FunSuite {
     val schemaInfo: SchemaInfo =
       new SchemaInfo(
         tablesByName = Map.empty,
-        colsByTableOrdered = Map.empty,
+        keyColumnsByTableOrdered = Map.empty,
+        dataColumnsByTableOrdered = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(primaryKeyColumn))),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -19,6 +19,7 @@ class PkStoreWorkflowTest extends FunSuite {
       new Column(
         table = table,
         name = null,
+        keyOrdinalPosition = 0,
         dataOrdinalPosition = 0,
         dataType = null
       )
@@ -83,6 +84,7 @@ class PkStoreWorkflowTest extends FunSuite {
       new Column(
         table = table,
         name = null,
+        keyOrdinalPosition = 0,
         dataOrdinalPosition = 0,
         dataType = null
       )

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -20,7 +20,7 @@ class PkStoreWorkflowTest extends FunSuite {
         table = table,
         name = null,
         keyOrdinalPosition = 0,
-        dataOrdinalPosition = 0,
+        dataOrdinalPosition = -1, // n/a
         dataType = null
       )
 
@@ -85,7 +85,7 @@ class PkStoreWorkflowTest extends FunSuite {
         table = table,
         name = null,
         keyOrdinalPosition = 0,
-        dataOrdinalPosition = 0,
+        dataOrdinalPosition = -1, // n/a
         dataType = null
       )
 

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -19,7 +19,7 @@ class PkStoreWorkflowTest extends FunSuite {
       new Column(
         table = table,
         name = null,
-        ordinalPosition = 0,
+        dataOrdinalPosition = 0,
         dataType = null
       )
 
@@ -83,7 +83,7 @@ class PkStoreWorkflowTest extends FunSuite {
       new Column(
         table = table,
         name = null,
-        ordinalPosition = 0,
+        dataOrdinalPosition = 0,
         dataType = null
       )
 


### PR DESCRIPTION
* Separate out the concept of the `keyOrdinalPosition` and the `dataOrdinalPosition` when dealing with columns.
* Separate out the concept of `keyColumns` from `dataColumns` in the schema info, and use each one over the other where appropriate.
* Only allow access to key data in the `Keys` class via a `PrimaryKey` or a `ForeignKey` -- don't allow access to the underlying raw data.
* Currently under the hood, the `Keys` class still contains all column data, not just key column data. Therefore currently `keyOrdinalPosition` is always equal to `dataOrdinalPosition` and `keyColumns` are always equal to `dataColumns`. However, in the future, `Keys` will only contain key column data, and so the columns and the ordinal positions will start to vary independently.