### PR TITLE
Increase type safety of Row type

### DIFF
--- a/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
@@ -11,7 +11,7 @@ private[db] class JdbcResultConverterImpl(schemaInfo: SchemaInfo) extends JdbcRe
   def convertToRows(jdbcResultSet: ResultSet, table: Table): Vector[Row] = {
     val cols: Seq[Column] = schemaInfo.dataColumnsByTableOrdered(table)
     val multipleRowsRawData = extractMultiRowRawData(jdbcResultSet, cols.size)
-    multipleRowsRawData.toVector
+    multipleRowsRawData.map(singleRowRawData => new Row(singleRowRawData)).toVector
   }
 
   override def convertToKeys(jdbcResultSet: ResultSet, table: Table): Vector[Keys] = {

--- a/src/main/scala/trw/dbsubsetter/db/impl/target/TargetDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/target/TargetDbAccessImpl.scala
@@ -15,12 +15,16 @@ private[db] class TargetDbAccessImpl(connStr: String, sch: SchemaInfo, connectio
   }
 
   override def insertRows(table: Table, rows: Vector[Row]): Unit = {
-
     val stmt = statements(table)
-    val cols = sch.dataColumnsByTableOrdered(table).size
 
     rows.foreach { row =>
-      (1 to cols).foreach(i => stmt.setObject(i, row(i - 1)))
+      row
+        .data
+        .zipWithIndex
+        .foreach { case (singleColumnValue, i) =>
+          stmt.setObject(i + 1, singleColumnValue)
+        }
+
       stmt.addBatch()
     }
 

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -10,7 +10,6 @@ package object db {
   type ColumnName = String
   type WhereClause = String
   type TypeName = String
-  type Row = Array[Any]
   type SqlQuery = String
   type ForeignKeySqlTemplates = Map[(ForeignKey, Table), SqlQuery]
   type PrimaryKeySqlTemplates = Map[(Table, Short), SqlQuery]
@@ -69,6 +68,9 @@ package object db {
   class ForeignKeyValue(val individualColumnValues: Seq[Any]) {
     val isEmpty: Boolean = individualColumnValues.forall(_ == null)
   }
+
+  // Represents a single row from the origin database including all columns
+  class Row(val data: Array[Any])
 
   // Represents a single row from the origin database including only primary and foreign key columns
   class Keys(data: Array[Any]) {

--- a/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
+++ b/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
@@ -181,13 +181,13 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
       insertStatement.clearParameters()
 
       rows.foreach { row =>
-        insertStatement.setObject(1, row(0))
-        insertStatement.setObject(2, row(1))
-        insertStatement.setObject(3, row(2))
-        insertStatement.setObject(4, row(3))
-        insertStatement.setObject(5, row(4))
-        insertStatement.setObject(6, row(5))
-        insertStatement.setObject(7, row(6))
+        insertStatement.setObject(1, row.data(0))
+        insertStatement.setObject(2, row.data(1))
+        insertStatement.setObject(3, row.data(2))
+        insertStatement.setObject(4, row.data(3))
+        insertStatement.setObject(5, row.data(4))
+        insertStatement.setObject(6, row.data(5))
+        insertStatement.setObject(7, row.data(6))
         insertStatement.addBatch()
       }
 
@@ -221,13 +221,13 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
       insertStatement.clearParameters()
 
       rows.zipWithIndex.foreach { case (row, rowIndex) =>
-        insertStatement.setObject(rowIndex * 7 + 1, row(0))
-        insertStatement.setObject(rowIndex * 7 + 2, row(1))
-        insertStatement.setObject(rowIndex * 7 + 3, row(2))
-        insertStatement.setObject(rowIndex * 7 + 4, row(3))
-        insertStatement.setObject(rowIndex * 7 + 5, row(4))
-        insertStatement.setObject(rowIndex * 7 + 6, row(5))
-        insertStatement.setObject(rowIndex * 7 + 7, row(6))
+        insertStatement.setObject(rowIndex * 7 + 1, row.data(0))
+        insertStatement.setObject(rowIndex * 7 + 2, row.data(1))
+        insertStatement.setObject(rowIndex * 7 + 3, row.data(2))
+        insertStatement.setObject(rowIndex * 7 + 4, row.data(3))
+        insertStatement.setObject(rowIndex * 7 + 5, row.data(4))
+        insertStatement.setObject(rowIndex * 7 + 6, row.data(5))
+        insertStatement.setObject(rowIndex * 7 + 7, row.data(6))
       }
 
       insertStatement.execute()
@@ -323,7 +323,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
 
     val rows = ArrayBuffer.empty[Row]
     while (resultSet.next()) {
-      val row: Row = Array(
+      val data: Array[Any] = Array(
         resultSet.getObject(1),
         resultSet.getObject(2),
         resultSet.getObject(3),
@@ -332,7 +332,7 @@ class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
         resultSet.getObject(6),
         resultSet.getObject(7)
       )
-      rows += row
+      rows += new Row(data)
     }
     rows.toVector
   }


### PR DESCRIPTION
Change `Row` from a type alias to an actual class, so that not just any `Array[Any]` could be considered a `Row` by the compiler.