### PR TITLE
Reduce data fetched for key calculation

### DIFF
--- a/src/main/scala/trw/dbsubsetter/db/DbMetadataQueries.scala
+++ b/src/main/scala/trw/dbsubsetter/db/DbMetadataQueries.scala
@@ -6,6 +6,8 @@ import trw.dbsubsetter.config.Config
 
 import scala.collection.mutable.ArrayBuffer
 
+
+// scalastyle:off
 private[db] object DbMetadataQueries {
   def queryDb(config: Config): DbMetadataQueryResult = {
     val conn = DriverManager.getConnection(config.originDbConnectionString)

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -30,7 +30,7 @@ object SchemaInfoRetrieval {
             val column: Column = new Column(
               table = table,
               name = c.name,
-              keyOrdinalPosition = i, // Placeholder value that will be mutated (corrected) later
+              keyOrdinalPosition = -1, // Placeholder value that will be mutated (corrected) later
               dataOrdinalPosition = i,
               dataType = columnType
             )
@@ -39,7 +39,7 @@ object SchemaInfoRetrieval {
         }
     }
 
-    val dataColumnsByTableOrdered: Map[Table, Vector[Column]] = {
+    val allColumnsByTableOrdered: Map[Table, Vector[Column]] = {
       colsByTableAndName.map { case (table, map) => table -> map.values.toVector.sortBy(_.dataOrdinalPosition) }
     }
 
@@ -48,7 +48,7 @@ object SchemaInfoRetrieval {
         .groupBy(pk => tablesByName(pk.schema, pk.table))
         .map { case (table, singleTablePrimaryKeyMetadataRows) =>
           val columnNames = singleTablePrimaryKeyMetadataRows.map(_.column).toSet
-          val orderedColumns = dataColumnsByTableOrdered(table).filter(c => columnNames.contains(c.name))
+          val orderedColumns = allColumnsByTableOrdered(table).filter(c => columnNames.contains(c.name))
           table -> new PrimaryKey(orderedColumns)
         }
     }
@@ -103,7 +103,7 @@ object SchemaInfoRetrieval {
     }
 
     val keyColumnsByTableOrdered: Map[Table, Vector[Column]] = {
-      dataColumnsByTableOrdered.map { case (table, allColumns) =>
+      allColumnsByTableOrdered.map { case (table, allColumns) =>
         val primaryKey: PrimaryKey = pksByTable(table)
         val foreignKeysFromTable: Seq[ForeignKey] = fksFromTable(table)
         val foreignKeysToTable: Seq[ForeignKey] = fksToTable(table)
@@ -114,20 +114,20 @@ object SchemaInfoRetrieval {
             foreignKeysToTable.exists(_.toCols.contains(col))
         }
 
-        val keyColumns: Seq[Column] = allColumns.filter(isKeyColumn)
+        val keyColumns: Vector[Column] = allColumns.filter(isKeyColumn)
 
         keyColumns.zipWithIndex.foreach { case (keyColumn, i) =>
           keyColumn.keyOrdinalPosition = i
         }
 
-        table -> allColumns.filter(isKeyColumn)
+        table -> keyColumns
       }
     }
 
     new SchemaInfo(
       tablesByName = tablesByName,
       keyColumnsByTableOrdered = keyColumnsByTableOrdered,
-      dataColumnsByTableOrdered = dataColumnsByTableOrdered,
+      dataColumnsByTableOrdered = allColumnsByTableOrdered,
       pksByTable = pksByTable,
       fksOrdered = foreignKeysOrdered,
       fksFromTable = fksFromTable,

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -37,9 +37,10 @@ package object db {
     val name: ColumnName,
     /*
      * The 0-indexed location of this column in query results where only primary and foreign key columns are included
-     * -1 if this column is not part of a primary or foreign key, as this column would not be included in that query
+     * -1 if this column is not part of a primary or foreign key, as this column would not be included in that query.
+     * TODO make this immutable
      */
-    val keyOrdinalPosition: Int,
+    var keyOrdinalPosition: Int,
     // The 0-indexed location of this column in query results where all columns are included
     val dataOrdinalPosition: Int,
     val dataType: ColumnType


### PR DESCRIPTION
When querying the origin DB for primary and foreign key calculation purposes, only include columns which are actually part of primary or foreign keys. Exclude all other columns which are not relevant to key calculation.

Achieves `Post Merge Cleanup Work: 5) Remove all non-primary-key and non-foreign-key row data from origin DB key-calculation queries, as it is no longer used` from issue https://github.com/bluerogue251/DBSubsetter/issues/33