### PR TITLE
Rename config options to reflect new system design

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ DBSubsetter is a tool for taking a logically consistent subset of a relational d
 
 Starting with a base condition specifying a set of rows from one or more tables, it respects foreign key constraints by recursively fetching the "parents" and (optionally) the "children" of those rows.
 
-This is useful for local development and testing or for exporting all the data belonging to a particular set of users or customers for debugging and sharing.
+This is useful for creating local development and testing datasets.
+It can also be used to export the data belonging to a particular set of users for debugging or sharing purposes.
 
 
 ## Project Goals
@@ -25,7 +26,7 @@ Please reach out by opening a GitHub ticket if you would like support for a diff
 
 ## Download and Usage Instructions
 
-1. Start with ample disk space, as DBSubsetter needs space to store intermediate results in tempfiles
+1. Start with ample disk space, as DBSubsetter needs space to store intermediate results in tempfiles.
 
 2. Load an empty schema from your "origin" database into your "target" database. See vendor-specific instructions for [Postgres](docs/pre_subset_postgres.md), [MySQL](docs/pre_subset_mysql.md), and [Microsoft SQL Server](docs/pre_subset_ms_sql_server.md).
  
@@ -59,7 +60,7 @@ Contributions of all kinds are welcome!
 
 Whether it is to fix a typo, improve the documentation, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on the project [GitHub page](https://github.com/bluerogue251/DBSubsetter).
 
-The only condition for contributing to this project is to follow our [code of conduct](CODE_OF_CONDUCT.md) so that everyone is treated with respect.
+All contributors are asked to follow our [code of conduct](CODE_OF_CONDUCT.md).
 
 
 ## Related Projects

--- a/README.md
+++ b/README.md
@@ -25,9 +25,11 @@ Please reach out by opening a GitHub ticket if you would like support for a diff
 
 ## Download and Usage Instructions
 
-1. Load an empty schema from your "origin" database into your "target" database. See vendor-specific instructions for [Postgres](docs/pre_subset_postgres.md), [MySQL](docs/pre_subset_mysql.md), and [Microsoft SQL Server](docs/pre_subset_ms_sql_server.md).
+1. Start with ample disk space, as DBSubsetter needs space to store intermediate results in tempfiles
+
+2. Load an empty schema from your "origin" database into your "target" database. See vendor-specific instructions for [Postgres](docs/pre_subset_postgres.md), [MySQL](docs/pre_subset_mysql.md), and [Microsoft SQL Server](docs/pre_subset_ms_sql_server.md).
  
-2. Download the DBSubsetter.jar file from our [latest release](https://github.com/bluerogue251/DBSubsetter/releases/latest) and run it with Java 8:
+3. Download the DBSubsetter.jar file from our [latest release](https://github.com/bluerogue251/DBSubsetter/releases/latest) and run it with Java 8:
 
 ```bash
 # Download the DBSubsetter.jar file
@@ -44,22 +46,12 @@ $ java -jar /path/to/DBSubsetter.jar \
     --originDbConnStr "jdbc:<driverName>://<originConnectionString>" \
     --targetDbConnStr "jdbc:<driverName>://<targetConnectionString>" \
     --baseQuery "your_schema.users ::: id % 100 = 0 ::: includeChildren" \
-    --originDbParallelism 8 \
-    --targetDbParallelism 8
+    --keyCalculationDbConnectionCount 8 \
+    --dataCopyDbConnectionCount 8
 ```
 
-3. After DBSubsetter exits, do any last steps as necessary. See vendor-specific instructions for [Postgres](docs/post_subset_postgres.md), [MySQL](docs/post_subset_mysql.md), and [Microsoft SQL Server](docs/post_subset_ms_sql_server.md).
+4. After DBSubsetter exits, do any last steps as necessary. See vendor-specific instructions for [Postgres](docs/post_subset_postgres.md), [MySQL](docs/post_subset_mysql.md), and [Microsoft SQL Server](docs/post_subset_ms_sql_server.md).
 
-
-## Resource Consumption
-
-Memory usage in the worst case will be proportional to the sum of:
-
-* The size of all primary keys in the target database.
-* The size of your largest single query result multiplied by 
-  (`--originDbParallelism` + `--targetDbParallelism`)
-
-Disk usage (in tempfiles) will be proportional to the size of all foreign keys in the target database.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Please reach out by opening a GitHub ticket if you would like support for a diff
 
 ## Download and Usage Instructions
 
-1. Start with ample disk space, as DBSubsetter needs space to store intermediate results in tempfiles.
+1. Start with ample disk space, as DBSubsetter stores intermediate results in tempfiles.
 
 2. Load an empty schema from your "origin" database into your "target" database. See vendor-specific instructions for [Postgres](docs/pre_subset_postgres.md), [MySQL](docs/pre_subset_mysql.md), and [Microsoft SQL Server](docs/pre_subset_ms_sql_server.md).
  
@@ -51,7 +51,7 @@ $ java -jar /path/to/DBSubsetter.jar \
     --dataCopyDbConnectionCount 8
 ```
 
-4. After DBSubsetter exits, do any last steps as necessary. See vendor-specific instructions for [Postgres](docs/post_subset_postgres.md), [MySQL](docs/post_subset_mysql.md), and [Microsoft SQL Server](docs/post_subset_ms_sql_server.md).
+4. After DBSubsetter exits, follow vendor-specific instructions for [Postgres](docs/post_subset_postgres.md), [MySQL](docs/post_subset_mysql.md), and [Microsoft SQL Server](docs/post_subset_ms_sql_server.md).
 
 
 ## Contributing
@@ -60,7 +60,7 @@ Contributions of all kinds are welcome!
 
 Whether it is to fix a typo, improve the documentation, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on the project [GitHub page](https://github.com/bluerogue251/DBSubsetter).
 
-All contributors are asked to follow our [code of conduct](CODE_OF_CONDUCT.md).
+Please follow our [code of conduct](CODE_OF_CONDUCT.md) when contributing.
 
 
 ## Related Projects

--- a/load-test/4-run.sh
+++ b/load-test/4-run.sh
@@ -18,8 +18,8 @@ echo "Running load test of school_db"
 java -Xmx4G -jar DBSubsetter.jar \
   --originDbConnStr "jdbc:postgresql://0.0.0.0:5432/school_db?user=postgres" \
   --targetDbConnStr "jdbc:postgresql://0.0.0.0:5433/school_db?user=postgres" \
-  --originDbParallelism 8 \
-  --targetDbParallelism 8 \
+  --keyCalculationDbConnectionCount 8 \
+  --dataCopyDbConnectionCount 8 \
   --schemas "school_db,Audit" \
   --baseQuery "school_db.Students ::: student_id % 25 = 0 ::: includeChildren" \
   --baseQuery "school_db.standalone_table ::: id < 4 ::: includeChildren" \
@@ -36,8 +36,8 @@ echo "Running load test of physics_db"
 nohup java -Xmx4G -jar DBSubsetter.jar \
   --originDbConnStr "jdbc:postgresql://0.0.0.0:5432/physics_db?user=postgres" \
   --targetDbConnStr "jdbc:postgresql://0.0.0.0:5433/physics_db?user=postgres" \
-  --originDbParallelism 8 \
-  --targetDbParallelism 8 \
+  --keyCalculationDbConnectionCount 8 \
+  --dataCopyDbConnectionCount 8 \
   --schemas "public" \
   --baseQuery "public.scientists ::: id in (2) ::: includeChildren" \
   --exposeMetrics &

--- a/observability-tools.sh
+++ b/observability-tools.sh
@@ -31,7 +31,7 @@ sleep 5
 curl \
   -X POST \
   -H 'Content-Type: application/json' \
-  --data '{"name": "prometheus", "type": "prometheus", "url": "http://localhost:9090", "access": "browser", "jsonData": { "timeInterval": "500ms" } }' \
+  --data '{"name": "prometheus", "type": "prometheus", "url": "http://ec2-54-224-104-135.compute-1.amazonaws.com:9090", "access": "browser", "jsonData": { "timeInterval": "500ms" } }' \
   admin:admin@localhost:3000/api/datasources
 
 echo ""

--- a/observability-tools.sh
+++ b/observability-tools.sh
@@ -31,7 +31,7 @@ sleep 5
 curl \
   -X POST \
   -H 'Content-Type: application/json' \
-  --data '{"name": "prometheus", "type": "prometheus", "url": "http://ec2-54-224-104-135.compute-1.amazonaws.com:9090", "access": "browser", "jsonData": { "timeInterval": "500ms" } }' \
+  --data '{"name": "prometheus", "type": "prometheus", "url": "http://localhost:9090", "access": "browser", "jsonData": { "timeInterval": "500ms" } }' \
   admin:admin@localhost:3000/api/datasources
 
 echo ""

--- a/src/main/scala/trw/dbsubsetter/chronicle/ChronicleQueueFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/chronicle/ChronicleQueueFactory.scala
@@ -10,7 +10,7 @@ object ChronicleQueueFactory {
 
   def createQueue(config: Config): SingleChronicleQueue = {
     val storageDir =
-      config.taskQueueDirOpt match {
+      config.tempfileStorageDirOpt match {
         case Some(dir) => dir.toPath
         case None => Files.createTempDirectory("DBSubsetter-")
       }

--- a/src/main/scala/trw/dbsubsetter/chronicle/ChronicleQueueFactory.scala
+++ b/src/main/scala/trw/dbsubsetter/chronicle/ChronicleQueueFactory.scala
@@ -10,7 +10,7 @@ object ChronicleQueueFactory {
 
   def createQueue(config: Config): SingleChronicleQueue = {
     val storageDir =
-      config.tempfileStorageDirOpt match {
+      config.tempfileStorageDirectoryOpt match {
         case Some(dir) => dir.toPath
         case None => Files.createTempDirectory("DBSubsetter-")
       }

--- a/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
+++ b/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
@@ -69,20 +69,18 @@ object CommandLineParser {
       .valueName("<int>")
       .action((dbp, c) => c.copy(keyCalculationDbConnectionCount = dbp))
       .text(
-        """Number of concurrent connections to the full-size origin DB
-          |                           For use in calculating dependencies between primary and foreign keys
-          |                           A good starting value is the number of CPU cores on your origin database machine
-          |                           (Note the total origin DB connection count is equal to --keyCalculationDbConnectionCount + --dataCopyDbConnectionCount)
+        """Concurrent connections to the Origin DB for calculating primary and foreign key dependencies
+          |                           A reasonable starting value is half the number of CPU cores on your origin database machine
+          |                           (Note the total Origin DB connection count is --keyCalculationDbConnectionCount + --dataCopyDbConnectionCount)
         """.stripMargin)
 
     opt[Int]("dataCopyDbConnectionCount")
       .valueName("<int>")
       .action((dbp, c) => c.copy(dataCopyDbConnectionCount = dbp))
       .text(
-        """Number of concurrent connections to both the full-size origin DB and the smaller target DB
-          |                           For use in copying full row data between the origin and target DBs
-          |                           A good starting value is the number of CPU cores on your target database machine
-          |                           (Note the total origin DB connection count is equal to --keyCalculationDbConnectionCount + --dataCopyDbConnectionCount)
+        """Concurrent connections to both the Origin DB and the Target DB for copying over full row data
+          |                           A reasonable starting value is half the number of CPU cores on your target database machine
+          |                           (Note the total Origin DB connection count is --keyCalculationDbConnectionCount + --dataCopyDbConnectionCount)
         """.stripMargin)
 
     opt[String]("foreignKey")

--- a/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
+++ b/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
@@ -72,6 +72,7 @@ object CommandLineParser {
         """Number of concurrent connections to the full-size origin DB
           |                           For use in calculating dependencies between primary and foreign keys
           |                           A good starting value is the number of CPU cores on your origin database machine
+          |                           (Note the total origin DB connection count is equal to --keyCalculationDbConnectionCount + --dataCopyDbConnectionCount)
         """.stripMargin)
 
     opt[Int]("dataCopyDbConnectionCount")
@@ -81,6 +82,7 @@ object CommandLineParser {
         """Number of concurrent connections to both the full-size origin DB and the smaller target DB
           |                           For use in copying full row data between the origin and target DBs
           |                           A good starting value is the number of CPU cores on your target database machine
+          |                           (Note the total origin DB connection count is equal to --keyCalculationDbConnectionCount + --dataCopyDbConnectionCount)
         """.stripMargin)
 
     opt[String]("foreignKey")

--- a/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
+++ b/src/main/scala/trw/dbsubsetter/config/CommandLineParser.scala
@@ -70,6 +70,7 @@ object CommandLineParser {
       .action((dbp, c) => c.copy(keyCalculationDbConnectionCount = dbp))
       .text(
         """Number of concurrent connections to the full-size origin DB
+          |                           For use in calculating dependencies between primary and foreign keys
           |                           A good starting value is the number of CPU cores on your origin database machine
         """.stripMargin)
 
@@ -77,7 +78,8 @@ object CommandLineParser {
       .valueName("<int>")
       .action((dbp, c) => c.copy(dataCopyDbConnectionCount = dbp))
       .text(
-        """Number of concurrent connections to the smaller target DB
+        """Number of concurrent connections to both the full-size origin DB and the smaller target DB
+          |                           For use in copying full row data between the origin and target DBs
           |                           A good starting value is the number of CPU cores on your target database machine
         """.stripMargin)
 
@@ -154,21 +156,21 @@ object CommandLineParser {
           |                           Can be specified multiple times
           |""".stripMargin)
 
-    opt[File]("tempfileStorageDir")
-      .valueName("</path/to/task/queue/dir>")
-      .action((dir, c) => c.copy(tempfileStorageDirOpt = Some(dir)))
+    opt[File]("tempfileStorageDirectory")
+      .valueName("</path/to/tempfile/storage/directory>")
+      .action((dir, c) => c.copy(tempfileStorageDirectoryOpt = Some(dir)))
       .validate { dir =>
         if (!dir.exists()) dir.mkdir()
         if (!dir.isDirectory) {
-          failure("--tempfileStorageDir must be a directory")
+          failure("--tempfileStorageDirectory must be a directory")
         } else if (dir.listFiles().nonEmpty) {
-          failure("--tempfileStorageDir must be an empty directory")
+          failure("--tempfileStorageDirectory must be an empty directory")
         } else {
           success
         }
       }
       .text(
-        """Directory in which DBSubsetter will store its queue of outstanding tasks
+        """Directory in which DBSubsetter will store tempfiles containing intermediate results
           |                           Defaults to the standard tempfile location of your OS
           |""".stripMargin)
 

--- a/src/main/scala/trw/dbsubsetter/config/Config.scala
+++ b/src/main/scala/trw/dbsubsetter/config/Config.scala
@@ -15,7 +15,7 @@ case class Config(
   cmdLinePrimaryKeys: List[CmdLinePrimaryKey] = List.empty,
   excludeColumns: Map[(SchemaName, TableName), Set[ColumnName]] = Map.empty.withDefaultValue(Set.empty),
   excludeTables: Set[(SchemaName, TableName)] = Set.empty,
-  tempfileStorageDirOpt: Option[File] = None,
+  tempfileStorageDirectoryOpt: Option[File] = None,
   isSingleThreadedDebugMode: Boolean = false,
   exposeMetrics: Boolean = false
 )

--- a/src/main/scala/trw/dbsubsetter/config/Config.scala
+++ b/src/main/scala/trw/dbsubsetter/config/Config.scala
@@ -9,14 +9,13 @@ case class Config(
   originDbConnectionString: String = "",
   targetDbConnectionString: String = "",
   baseQueries: Vector[((SchemaName, TableName), WhereClause, Boolean)] = Vector.empty,
-  // TODO rework these to be "Key query database connections" and "Data copy database connections"
-  originDbParallelism: Int = 1,
-  targetDbParallelism: Int = 1,
+  keyCalculationDbConnectionCount: Int = 1,
+  dataCopyDbConnectionCount: Int = 1,
   cmdLineForeignKeys: List[CmdLineForeignKey] = List.empty,
   cmdLinePrimaryKeys: List[CmdLinePrimaryKey] = List.empty,
   excludeColumns: Map[(SchemaName, TableName), Set[ColumnName]] = Map.empty.withDefaultValue(Set.empty),
   excludeTables: Set[(SchemaName, TableName)] = Set.empty,
-  taskQueueDirOpt: Option[File] = None,
+  tempfileStorageDirOpt: Option[File] = None,
   isSingleThreadedDebugMode: Boolean = false,
   exposeMetrics: Boolean = false
 )

--- a/src/test/scala/util/runner/TestSubsetRunner.scala
+++ b/src/test/scala/util/runner/TestSubsetRunner.scala
@@ -20,8 +20,8 @@ object TestSubsetRunner {
   def runSubsetInAkkaStreamsMode[T <: Database](containers: DatabaseSet[T], programArgs: Array[String]): Long = {
     val defaultArgs: Array[String] = Array(
       "--originDbConnStr", containers.origin.connectionString,
-      "--originDbParallelism", "10",
-      "--targetDbParallelism", "10",
+      "--keyCalculationDbConnectionCount", "10",
+      "--dataCopyDbConnectionCount", "10",
       "--targetDbConnStr", containers.targetAkkaStreams.connectionString,
       "--exposeMetrics"
     )


### PR DESCRIPTION
Some of the config param names were out of date after the latest changes to the overall system design. Renaming them here to keep the CLI options in sync with how the system works.