### PR TITLE
Tweaks to metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ DBSubsetter is a tool for taking a logically consistent subset of a relational d
 Starting with a base condition specifying a set of rows from one or more tables, it respects foreign key constraints by recursively fetching the "parents" and (optionally) the "children" of those rows.
 
 This is useful for creating local development and testing datasets.
-It can also be used to export the data belonging to a particular set of users for debugging or sharing purposes.
+It can also be used to export the data belonging to a particular set of users.
 
 
 ## Project Goals
@@ -26,11 +26,9 @@ Please reach out by opening a GitHub ticket if you would like support for a diff
 
 ## Download and Usage Instructions
 
-1. Start with ample disk space, as DBSubsetter stores intermediate results in tempfiles.
-
-2. Load an empty schema from your "origin" database into your "target" database. See vendor-specific instructions for [Postgres](docs/pre_subset_postgres.md), [MySQL](docs/pre_subset_mysql.md), and [Microsoft SQL Server](docs/pre_subset_ms_sql_server.md).
+1. Load an empty schema from your "origin" database into your "target" database. See vendor-specific instructions for [Postgres](docs/pre_subset_postgres.md), [MySQL](docs/pre_subset_mysql.md), and [Microsoft SQL Server](docs/pre_subset_ms_sql_server.md).
  
-3. Download the DBSubsetter.jar file from our [latest release](https://github.com/bluerogue251/DBSubsetter/releases/latest) and run it with Java 8:
+2. Download the DBSubsetter.jar file from our [latest release](https://github.com/bluerogue251/DBSubsetter/releases/latest) and run it with Java 8:
 
 ```bash
 # Download the DBSubsetter.jar file
@@ -51,14 +49,13 @@ $ java -jar /path/to/DBSubsetter.jar \
     --dataCopyDbConnectionCount 8
 ```
 
-4. After DBSubsetter exits, follow vendor-specific instructions for [Postgres](docs/post_subset_postgres.md), [MySQL](docs/post_subset_mysql.md), and [Microsoft SQL Server](docs/post_subset_ms_sql_server.md).
+3. After DBSubsetter exits, follow vendor-specific instructions for [Postgres](docs/post_subset_postgres.md), [MySQL](docs/post_subset_mysql.md), and [Microsoft SQL Server](docs/post_subset_ms_sql_server.md).
 
 
 ## Contributing
 
 Contributions of all kinds are welcome!
-
-Whether it is to fix a typo, improve the documentation, report or fix a bug, add a new feature, or whatever else you have in mind, feel free to open an issue or a pull request on the project [GitHub page](https://github.com/bluerogue251/DBSubsetter).
+Feel free to open an issue or a pull request on the project [GitHub page](https://github.com/bluerogue251/DBSubsetter).
 
 Please follow our [code of conduct](CODE_OF_CONDUCT.md) when contributing.
 

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -254,10 +254,10 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "PendingTasks",
+            "expr": "PendingForeignKeyTasks",
             "format": "time_series",
             "intervalFactor": 1,
-            "legendFormat": "Pending Task Count",
+            "legendFormat": "Pending Foreign Key Task Count",
             "refId": "A"
           }
         ],
@@ -265,7 +265,7 @@
         "timeFrom": null,
         "timeRegions": [],
         "timeShift": null,
-        "title": "Pending Tasks",
+        "title": "Pending Foreign Key Task Count",
         "tooltip": {
           "shared": true,
           "sort": 0,
@@ -637,18 +637,32 @@
             "refId": "C"
           },
           {
-            "expr": "rate(TaskEnqueueDuration_sum[1s]) / rate(TaskEnqueueDuration_count[1s])",
+            "expr": "rate(ForeignKeyTaskEnqueueDuration_sum[1s]) / rate(ForeignKeyTaskEnqueueDuration_count[1s])",
             "format": "time_series",
             "intervalFactor": 1,
-            "legendFormat": "FkTask Buffer Enqueue",
+            "legendFormat": "Foreign Key Task Buffer Enqueue",
             "refId": "D"
           },
           {
-            "expr": "rate(TaskDequeueDuration_sum[1s]) / rate(TaskDequeueDuration_count[1s])",
+            "expr": "rate(ForeignKeyTaskDequeueDuration_sum[1s]) / rate(ForeignKeyTaskDequeueDuration_count[1s])",
             "format": "time_series",
             "intervalFactor": 1,
-            "legendFormat": "FkTask Buffer Dequeue",
+            "legendFormat": "Foreign Key Task Buffer Dequeue",
             "refId": "E"
+          },
+          {
+            "expr": "rate(DataCopyTaskEnqueueDuration_sum[1s]) / rate(DataCopyTaskEnqueueDuration_count[1s])",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Data Copy Task Buffer Enqueue",
+            "refId": "F"
+          },
+          {
+            "expr": "rate(DataCopyTaskDequeueDuration_sum[1s]) / rate(DataCopyTaskDequeueDuration_count[1s])",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Data Copy Task Buffer Dequeue",
+            "refId": "G"
           }
         ],
         "thresholds": [],

--- a/grafana-dashboard.json
+++ b/grafana-dashboard.json
@@ -649,20 +649,6 @@
             "intervalFactor": 1,
             "legendFormat": "Foreign Key Task Buffer Dequeue",
             "refId": "E"
-          },
-          {
-            "expr": "rate(DataCopyTaskEnqueueDuration_sum[1s]) / rate(DataCopyTaskEnqueueDuration_count[1s])",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Data Copy Task Buffer Enqueue",
-            "refId": "F"
-          },
-          {
-            "expr": "rate(DataCopyTaskDequeueDuration_sum[1s]) / rate(DataCopyTaskDequeueDuration_count[1s])",
-            "format": "time_series",
-            "intervalFactor": 1,
-            "legendFormat": "Data Copy Task Buffer Dequeue",
-            "refId": "G"
           }
         ],
         "thresholds": [],
@@ -670,6 +656,99 @@
         "timeRegions": [],
         "timeShift": null,
         "title": "Average Time Spent Per Non-DB Operation (1 operation ~= 1 row)",
+        "tooltip": {
+          "shared": true,
+          "sort": 0,
+          "value_type": "individual"
+        },
+        "type": "graph",
+        "xaxis": {
+          "buckets": null,
+          "mode": "time",
+          "name": null,
+          "show": true,
+          "values": []
+        },
+        "yaxes": [
+          {
+            "format": "s",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": true
+          },
+          {
+            "format": "short",
+            "label": null,
+            "logBase": 1,
+            "max": null,
+            "min": null,
+            "show": false
+          }
+        ],
+        "yaxis": {
+          "align": false,
+          "alignLevel": null
+        }
+      },
+      {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": "prometheus",
+        "description": "",
+        "fill": 1,
+        "gridPos": {
+          "h": 5,
+          "w": 24,
+          "x": 0,
+          "y": 35
+        },
+        "id": 25,
+        "legend": {
+          "avg": false,
+          "current": false,
+          "max": false,
+          "min": false,
+          "show": false,
+          "total": false,
+          "values": false
+        },
+        "lines": true,
+        "linewidth": 1,
+        "links": [],
+        "nullPointMode": "null",
+        "percentage": false,
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+          {
+            "expr": "rate(DataCopyTaskEnqueueDuration_sum[1s]) / rate(DataCopyTaskEnqueueDuration_count[1s])",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Enqueue Data Copy Task",
+            "refId": "G"
+          },
+          {
+            "expr": "rate(DataCopyTaskDequeueDuration_sum[1s]) / rate(DataCopyTaskDequeueDuration_count[1s])",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": "Dequeue Data Copy Task",
+            "refId": "A"
+          }
+        ],
+        "thresholds": [],
+        "timeFrom": null,
+        "timeRegions": [],
+        "timeShift": null,
+        "title": "Average Time Spent Per Data Copy Queue Operation (1 operation may include many rows)",
         "tooltip": {
           "shared": true,
           "sort": 0,

--- a/src/main/scala/trw/dbsubsetter/ApplicationAkkaStreams.scala
+++ b/src/main/scala/trw/dbsubsetter/ApplicationAkkaStreams.scala
@@ -8,7 +8,6 @@ import trw.dbsubsetter.config.Config
 import trw.dbsubsetter.datacopyqueue.{DataCopyQueue, DataCopyQueueFactory}
 import trw.dbsubsetter.db.{DbAccessFactory, SchemaInfo}
 import trw.dbsubsetter.fktaskqueue.{ForeignKeyTaskQueue, ForeignKeyTaskQueueFactory}
-import trw.dbsubsetter.metrics.Metrics
 import trw.dbsubsetter.workflow._
 
 import scala.concurrent.duration.Duration
@@ -25,10 +24,6 @@ object ApplicationAkkaStreams {
     val fkTaskCreationWorkflow: FkTaskCreationWorkflow = new FkTaskCreationWorkflow(schemaInfo)
     val fkTaskQueue: ForeignKeyTaskQueue = ForeignKeyTaskQueueFactory.build(config, schemaInfo)
     val dataCopyQueue: DataCopyQueue = DataCopyQueueFactory.buildDataCopyQueue(config, schemaInfo)
-
-    if (config.exposeMetrics) {
-      Metrics.PendingTasksGauge.inc(config.baseQueries.size)
-    }
 
     val subsettingFuture: Future[Done] =
       Subsetting

--- a/src/main/scala/trw/dbsubsetter/fktaskqueue/impl/ForeignKeyTaskQueueInstrumented.scala
+++ b/src/main/scala/trw/dbsubsetter/fktaskqueue/impl/ForeignKeyTaskQueueInstrumented.scala
@@ -7,11 +7,11 @@ import trw.dbsubsetter.workflow.ForeignKeyTask
 
 private[fktaskqueue] final class ForeignKeyTaskQueueInstrumented(delegatee: ForeignKeyTaskQueue) extends ForeignKeyTaskQueue {
 
-  private[this] val pendingTaskCount = Metrics.PendingTasksGauge
+  private[this] val pendingTaskCount = Metrics.PendingForeignKeyTasks
 
-  private[this] val taskEnqueueDuration = Metrics.TaskEnqueueDuration
+  private[this] val taskEnqueueDuration = Metrics.ForeignKeyTaskEnqueueDuration
 
-  private[this] val taskDequeueDuration = Metrics.TaskDequeueDuration
+  private[this] val taskDequeueDuration = Metrics.ForeignKeyTaskDequeueDuration
 
   override def enqueue(foreignKeyTask: ForeignKeyTask): Unit = {
     val runnable: Runnable = () => delegatee.enqueue(foreignKeyTask)

--- a/src/main/scala/trw/dbsubsetter/metrics/Metrics.scala
+++ b/src/main/scala/trw/dbsubsetter/metrics/Metrics.scala
@@ -90,25 +90,25 @@ object Metrics {
       .buckets(dbDurationPerRowBuckets: _*)
       .register()
 
-  val PendingTasksGauge: Gauge =
+  val PendingForeignKeyTasks: Gauge =
     Gauge
       .build()
-      .name("PendingTasks")
+      .name("PendingForeignKeyTasks")
       .help("n/a")
       .register()
 
-  val TaskEnqueueDuration: Histogram =
+  val ForeignKeyTaskEnqueueDuration: Histogram =
     Histogram
       .build()
-      .name("TaskEnqueueDuration")
+      .name("ForeignKeyTaskEnqueueDuration")
       .help("n/a")
       .buckets(offHeapQueueDurationBuckets: _*)
       .register()
 
-  val TaskDequeueDuration: Histogram =
+  val ForeignKeyTaskDequeueDuration: Histogram =
     Histogram
       .build()
-      .name("TaskDequeueDuration")
+      .name("ForeignKeyTaskDequeueDuration")
       .help("n/a")
       .buckets(offHeapQueueDurationBuckets: _*)
       .register()


### PR DESCRIPTION
Make the pending task count just for Foreign Key Tasks and not include base queries (combining the two was causing some confusion).

Add Data Copy Task Queue enqueue/dequeue stats to Grafana. Also tweak the README a bit.