### PR TITLE
Test composite keys

### DIFF
--- a/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
+++ b/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
@@ -81,7 +81,7 @@ private object InMemoryPrimaryKeyStore {
     if (primaryKeyValue.individualColumnValues.size == 1) {
       primaryKeyValue.individualColumnValues.head
     } else {
-      primaryKeyValue.individualColumnValues
+      primaryKeyValue.individualColumnValues.toArray
     }
   }
 }

--- a/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
+++ b/src/main/scala/trw/dbsubsetter/primarykeystore/impl/InMemoryPrimaryKeyStore.scala
@@ -81,7 +81,7 @@ private object InMemoryPrimaryKeyStore {
     if (primaryKeyValue.individualColumnValues.size == 1) {
       primaryKeyValue.individualColumnValues.head
     } else {
-      primaryKeyValue.individualColumnValues.toArray
+      primaryKeyValue.individualColumnValues
     }
   }
 }

--- a/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
+++ b/src/main/scala/trw/dbsubsetter/workflow/TargetDbWorkflow.scala
@@ -23,6 +23,14 @@ final class TargetDbWorkflow(dbAccessFactory: DbAccessFactory) {
     val rowsToInsert: Vector[Row] =
       originDbAccess.getRowsFromPrimaryKeyValues(dataCopyTask.table, pkValues)
 
+    if (!rowsToInsert.size.equals(pkValues.size)) {
+      val message: String =
+        s"Number of rows fetched did not equal number of primary keys. " +
+          s"Rows fetched: ${rowsToInsert.size}. " +
+          s"Primary keys to fetch by: ${pkValues.size}"
+      throw new IllegalStateException(message)
+    }
+
     targetDbAccess.insertRows(dataCopyTask.table, rowsToInsert)
   }
 }

--- a/src/test/scala/e2e/compositekeys/CompositeKeysDDL.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysDDL.scala
@@ -1,0 +1,41 @@
+package e2e.compositekeys
+
+import slick.jdbc.JdbcProfile
+import slick.lifted.PrimaryKey
+
+class CompositeKeysDDL(val profile: JdbcProfile) {
+  import profile.api._
+
+  lazy val schema: profile.SchemaDescription = ParentTable.schema ++ ChildTable.schema
+
+  /**
+    * parents
+    */
+  case class ParentTableRow(idOne: Int, idTwo: Int)
+
+  class ParentTableDefinition(_tableTag: Tag) extends profile.api.Table[ParentTableRow](_tableTag, "parents") {
+    def * = (idOne, idTwo) <> (ParentTableRow.tupled, ParentTableRow.unapply)
+
+    val idOne: Rep[Int] = column[Int]("id_one")
+    val idTwo: Rep[Int] = column[Int]("id_two")
+    val pk: PrimaryKey = primaryKey("composite_pk", (idOne, idTwo))
+  }
+
+  lazy val ParentTable = new TableQuery(tag => new ParentTableDefinition(tag))
+
+  /**
+    * children
+    */
+  case class ChildTableRow(id: Int, parentIdOne: Int, parentIdTwo: Int)
+
+  class ChildTableDefinition(_tableTag: Tag) extends profile.api.Table[ChildTableRow](_tableTag, "children") {
+    def * = (id, parentIdOne, parentIdTwo) <> (ChildTableRow.tupled, ChildTableRow.unapply)
+
+    val id: Rep[Int] = column[Int]("id", O.PrimaryKey)
+    val parentIdOne: Rep[Int] = column[Int]("parent_id_one")
+    val parentIdTwo: Rep[Int] = column[Int]("parent_id_two")
+    lazy val fk = foreignKey("foreign_key", (parentIdOne, parentIdTwo), ParentTable)((pt: ParentTableDefinition) => (pt.idOne, pt.idTwo))
+  }
+
+  lazy val ChildTable = new TableQuery(tag => new ChildTableDefinition(tag))
+}

--- a/src/test/scala/e2e/compositekeys/CompositeKeysDDL.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysDDL.scala
@@ -13,7 +13,7 @@ class CompositeKeysDDL(val profile: JdbcProfile) {
     */
   case class ParentTableRow(idOne: Int, idTwo: Int)
 
-  class ParentTableDefinition(_tableTag: Tag) extends profile.api.Table[ParentTableRow](_tableTag, "parents") {
+  class ParentTable(_tableTag: Tag) extends profile.api.Table[ParentTableRow](_tableTag, "parents") {
     def * = (idOne, idTwo) <> (ParentTableRow.tupled, ParentTableRow.unapply)
 
     val idOne: Rep[Int] = column[Int]("id_one")
@@ -21,21 +21,21 @@ class CompositeKeysDDL(val profile: JdbcProfile) {
     val pk: PrimaryKey = primaryKey("composite_pk", (idOne, idTwo))
   }
 
-  lazy val ParentTable = new TableQuery(tag => new ParentTableDefinition(tag))
+  lazy val ParentTable = new TableQuery(tag => new ParentTable(tag))
 
   /**
     * children
     */
   case class ChildTableRow(id: Int, parentIdOne: Int, parentIdTwo: Int)
 
-  class ChildTableDefinition(_tableTag: Tag) extends profile.api.Table[ChildTableRow](_tableTag, "children") {
+  class ChildTable(_tableTag: Tag) extends profile.api.Table[ChildTableRow](_tableTag, "children") {
     def * = (id, parentIdOne, parentIdTwo) <> (ChildTableRow.tupled, ChildTableRow.unapply)
 
     val id: Rep[Int] = column[Int]("id", O.PrimaryKey)
     val parentIdOne: Rep[Int] = column[Int]("parent_id_one")
     val parentIdTwo: Rep[Int] = column[Int]("parent_id_two")
-    lazy val fk = foreignKey("foreign_key", (parentIdOne, parentIdTwo), ParentTable)((pt: ParentTableDefinition) => (pt.idOne, pt.idTwo))
+    lazy val fk = foreignKey("foreign_key", (parentIdOne, parentIdTwo), ParentTable)(t => (t.idOne, t.idTwo))
   }
 
-  lazy val ChildTable = new TableQuery(tag => new ChildTableDefinition(tag))
+  lazy val ChildTable = new TableQuery(tag => new ChildTable(tag))
 }

--- a/src/test/scala/e2e/compositekeys/CompositeKeysDML.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysDML.scala
@@ -1,0 +1,28 @@
+package e2e.compositekeys
+
+import slick.dbio.{DBIOAction, Effect, NoStream}
+
+object CompositeKeysDML {
+  def dbioSeq(ddl: CompositeKeysDDL): DBIOAction[Unit, NoStream, Effect.Write] = {
+    import ddl._
+    import ddl.profile.api._
+    slick.dbio.DBIO.seq(
+      ParentTable ++= Seq(
+        ParentTableRow(1, 2),
+        ParentTableRow(3, 4),
+        ParentTableRow(5, 6)
+      ),
+      ChildTable ++= Seq(
+        ChildTableRow(100, 1, 2),
+        ChildTableRow(101, 1, 2),
+        ChildTableRow(102, 1, 2),
+        ChildTableRow(103, 3, 4),
+        ChildTableRow(104, 3, 4),
+        ChildTableRow(105, 3, 4),
+        ChildTableRow(106, 5, 6),
+        ChildTableRow(107, 5, 6),
+        ChildTableRow(108, 5, 6)
+      )
+    )
+  }
+}

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTest.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTest.scala
@@ -1,0 +1,36 @@
+package e2e.compositekeys
+
+import org.scalatest.FunSuiteLike
+import util.assertion.AssertionUtil
+import util.slick.SlickUtil
+
+trait CompositeKeysTest extends FunSuiteLike with AssertionUtil {
+  val testName = "composite_keys"
+
+  protected val profile: slick.jdbc.JdbcProfile
+
+  protected def originSlick: slick.jdbc.JdbcBackend#DatabaseDef
+
+  private val ddl: CompositeKeysDDL = new CompositeKeysDDL(profile)
+
+  import ddl.profile.api._
+
+  protected def prepareOriginDDL(): Unit = {
+    SlickUtil.ddl(originSlick, ddl.schema.create)
+  }
+
+  protected def prepareOriginDML(): Unit = {
+    SlickUtil.dml(originSlick, CompositeKeysDML.dbioSeq(ddl))
+  }
+
+  test("Correct parent table records were included") {
+    assertCount(ddl.ParentTable, 2)
+    assertResult(ddl.ParentTable.map(_.idOne).sorted.result, Seq[Int](1, 5))
+    assertResult(ddl.ParentTable.map(_.idTwo).sorted.result, Seq[Int](2, 6))
+  }
+
+  test("Correct child table records were included") {
+    assertCount(ddl.ChildTable, 5)
+    assertResult(ddl.ChildTable.map(_.id).sorted.result, Seq[Int](100, 101, 106, 107, 108))
+  }
+}

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestMySql.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestMySql.scala
@@ -8,7 +8,7 @@ class CompositeKeysTestMySql extends AbstractMysqlEndToEndTest with CompositeKey
     "--schemas", "composite_keys",
   // Include the same parent in two different base queries
   "--baseQuery", "composite_keys.parents ::: (id_one, id_two) = (5, 6) ::: includeChildren",
-  "--baseQuery", "composite_keys.parents ::: id_one = 5 and id_two = 6 ::: includeChildren",
+  "--baseQuery", "composite_keys.parents ::: (id_one, id_two) = (5, 6) ::: includeChildren",
   // Include two different children with the same parent
   "--baseQuery", "composite_keys.children ::: id = 100 ::: excludeChildren",
   "--baseQuery", "composite_keys.children ::: id = 101 ::: excludeChildren"

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestMySql.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestMySql.scala
@@ -1,0 +1,16 @@
+package e2e.compositekeys
+
+import e2e.AbstractMysqlEndToEndTest
+
+class CompositeKeysTestMySql extends AbstractMysqlEndToEndTest with CompositeKeysTest {
+
+  override val programArgs = Array(
+    "--schemas", "composite_keys",
+  // Include the same parent in two different base queries
+  "--baseQuery", "composite_keys.parents ::: (id_one, id_two) = (5, 6) ::: includeChildren",
+  "--baseQuery", "composite_keys.parents ::: id_one = 5 and id_two = 6 ::: includeChildren",
+  // Include two different children with the same parent
+  "--baseQuery", "composite_keys.children ::: id = 100 ::: excludeChildren",
+  "--baseQuery", "composite_keys.children ::: id = 101 ::: excludeChildren"
+  )
+}

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestPostgreSQL.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestPostgreSQL.scala
@@ -8,7 +8,7 @@ class CompositeKeysTestPostgreSQL extends AbstractPostgresqlEndToEndTest with Co
     "--schemas", "public",
     // Include the same parent in two different base queries
     "--baseQuery", "public.parents ::: (id_one, id_two) = (5, 6) ::: includeChildren",
-    "--baseQuery", "public.parents ::: id_one = 5 and id_two = 6 ::: includeChildren",
+    "--baseQuery", "public.parents ::: (id_one, id_two) = (5, 6) ::: includeChildren",
     // Include two different children with the same parent
     "--baseQuery", "public.children ::: id = 100 ::: excludeChildren",
     "--baseQuery", "public.children ::: id = 101 ::: excludeChildren"

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestPostgreSQL.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestPostgreSQL.scala
@@ -1,0 +1,16 @@
+package e2e.compositekeys
+
+import e2e.AbstractPostgresqlEndToEndTest
+
+class CompositeKeysTestPostgreSQL extends AbstractPostgresqlEndToEndTest with CompositeKeysTest {
+
+  override val programArgs = Array(
+    "--schemas", "public",
+    // Include the same parent in two different base queries
+    "--baseQuery", "public.parents ::: (id_one, id_two) = (5, 6) ::: includeChildren",
+    "--baseQuery", "public.parents ::: id_one = 5 and id_two = 6 ::: includeChildren",
+    // Include two different children with the same parent
+    "--baseQuery", "public.children ::: id = 100 ::: excludeChildren",
+    "--baseQuery", "public.children ::: id = 101 ::: excludeChildren"
+  )
+}

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestSqlServer.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestSqlServer.scala
@@ -8,7 +8,7 @@ class CompositeKeysTestSqlServer extends AbstractSqlServerEndToEndTest with Comp
     "--schemas", "dbo",
   // Include the same parent in two different base queries
   "--baseQuery", "dbo.parents ::: id_one = 5 and id_two = 6 ::: includeChildren",
-  "--baseQuery", "dbo.parents ::: id_one = 2 + 3 and id_two = 3 + 3 ::: includeChildren",
+  "--baseQuery", "dbo.parents ::: id_one = 5 and id_two = 6 ::: includeChildren",
   // Include two different children with the same parent
   "--baseQuery", "dbo.children ::: id = 100 ::: excludeChildren",
   "--baseQuery", "dbo.children ::: id = 101 ::: excludeChildren"

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestSqlServer.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestSqlServer.scala
@@ -1,0 +1,16 @@
+package e2e.compositekeys
+
+import e2e.AbstractSqlServerEndToEndTest
+
+class CompositeKeysTestSqlServer extends AbstractSqlServerEndToEndTest with CompositeKeysTest {
+
+  override val programArgs = Array(
+    "--schemas", "dbo",
+  // Include the same parent in two different base queries
+  "--baseQuery", "dbo.parents ::: id_one = 5 and id_two = 6 ::: includeChildren",
+  "--baseQuery", "dbo.parents ::: id_one = 2 + 3 and id_two = 3 + 3 ::: includeChildren",
+  // Include two different children with the same parent
+  "--baseQuery", "dbo.children ::: id = 100 ::: excludeChildren",
+  "--baseQuery", "dbo.children ::: id = 101 ::: excludeChildren"
+  )
+}


### PR DESCRIPTION
Closes https://github.com/bluerogue251/DBSubsetter/issues/115

The edge case which https://github.com/bluerogue251/DBSubsetter/issues/115 was worrying about was in fact already working correctly, since composite primary keys were stored in a `Vector` rather than in an `Array`. This meant that equals/hashCode worked out of the box for them.

Although here we've only tested multi-column primary keys with `Int` type columns, in theory this should work with any data type where equals/hashcode works. I previously wanted to try writing this test with an `(Int, String)` multi column foreign key, but unfortunately Slick had trouble creating this in MySQL.

Incidentally also closes https://github.com/bluerogue251/DBSubsetter/issues/88