### PR TITLE
Refactor Test Abstractions To Prep for Schema Validation Tests

### DIFF
--- a/src/test/scala/e2e/DbEnabledTest.scala
+++ b/src/test/scala/e2e/DbEnabledTest.scala
@@ -3,7 +3,6 @@ package e2e
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import slick.jdbc.JdbcBackend
 import util.db.{Database, DatabaseSet}
-import util.runner.TestSubsetRunner
 
 abstract class DbEnabledTest[T <: Database] extends FunSuite with BeforeAndAfterAll {
   /*
@@ -22,18 +21,6 @@ abstract class DbEnabledTest[T <: Database] extends FunSuite with BeforeAndAfter
   protected def prepareOriginDML(): Unit
 
   protected def prepareTargetDDL(): Unit
-
-  protected def programArgs: Array[String]
-
-  protected def runSubsetInSingleThreadedMode(): Unit = {
-    TestSubsetRunner.runSubsetInSingleThreadedMode(dbs, programArgs)
-  }
-
-  protected def runSubsetInAkkaStreamsMode(): Unit = {
-    TestSubsetRunner.runSubsetInAkkaStreamsMode(dbs, programArgs)
-  }
-
-  protected def postSubset(): Unit
 
   protected def teardownOriginContainer(): Unit = {} // No-op by default
 
@@ -76,25 +63,6 @@ abstract class DbEnabledTest[T <: Database] extends FunSuite with BeforeAndAfter
      * Set up the DDL (but NOT the DML) in the target DB
      */
     prepareTargetDDL()
-
-
-    /*
-     * Run subsetting to copy a subset of the DML from the origin DB to the target DBs
-     */
-    runSubsetInSingleThreadedMode()
-    runSubsetInAkkaStreamsMode()
-
-    /*
-     * Do any steps necessary after subsetting, such as re-enabling foreign keys, re-adding indices
-     * to the target DBs, etc.
-     */
-    postSubset()
-
-    /*
-     * All of our setup is now done. We are now ready to make assertions on the contents of the
-     * target DBs to ensure that our program copied the correct data from the origin to the target
-     * DBs.
-     */
   }
 
   override protected def afterAll(): Unit = {

--- a/src/test/scala/e2e/DbEnabledTest.scala
+++ b/src/test/scala/e2e/DbEnabledTest.scala
@@ -5,7 +5,7 @@ import slick.jdbc.JdbcBackend
 import util.db.{Database, DatabaseSet}
 import util.runner.TestSubsetRunner
 
-abstract class AbstractEndToEndTest[T <: Database] extends FunSuite with BeforeAndAfterAll {
+abstract class DbEnabledTest[T <: Database] extends FunSuite with BeforeAndAfterAll {
   /*
    * Concrete test classes must override the following
    */

--- a/src/test/scala/e2e/DbEnabledTest.scala
+++ b/src/test/scala/e2e/DbEnabledTest.scala
@@ -4,6 +4,9 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 import slick.jdbc.JdbcBackend
 import util.db.{Database, DatabaseSet}
 
+/**
+  * A test which requires access to a running database.
+  */
 abstract class DbEnabledTest[T <: Database] extends FunSuite with BeforeAndAfterAll {
   /*
    * Concrete test classes must override the following

--- a/src/test/scala/e2e/MySqlEnabledTest.scala
+++ b/src/test/scala/e2e/MySqlEnabledTest.scala
@@ -7,7 +7,7 @@ import scala.sys.process._
 import scala.util.Properties
 
 /**
-  * A test which requires access to a MySql database.
+  * A test which requires access to a running MySql database.
   */
 abstract class MySqlEnabledTest extends DbEnabledTest[MySqlDatabase] {
   override protected val profile = slick.jdbc.MySQLProfile

--- a/src/test/scala/e2e/MySqlEnabledTest.scala
+++ b/src/test/scala/e2e/MySqlEnabledTest.scala
@@ -6,6 +6,9 @@ import util.db._
 import scala.sys.process._
 import scala.util.Properties
 
+/**
+  * A test which requires access to a MySql database.
+  */
 abstract class MySqlEnabledTest extends DbEnabledTest[MySqlDatabase] {
   override protected val profile = slick.jdbc.MySQLProfile
 
@@ -67,8 +70,6 @@ abstract class MySqlEnabledTest extends DbEnabledTest[MySqlDatabase] {
     MysqlEndToEndTestUtil.preSubsetDdlSync(dbs.origin, dbs.targetSingleThreaded, allSchemas)
     MysqlEndToEndTestUtil.preSubsetDdlSync(dbs.origin, dbs.targetAkkaStreams, allSchemas)
   }
-
-  override protected def postSubset(): Unit = {} // No-op
 }
 
 object MysqlEndToEndTestUtil {

--- a/src/test/scala/e2e/MySqlEnabledTest.scala
+++ b/src/test/scala/e2e/MySqlEnabledTest.scala
@@ -6,7 +6,7 @@ import util.db._
 import scala.sys.process._
 import scala.util.Properties
 
-abstract class AbstractMysqlEndToEndTest extends AbstractEndToEndTest[MySqlDatabase] {
+abstract class MySqlEnabledTest extends DbEnabledTest[MySqlDatabase] {
   override protected val profile = slick.jdbc.MySQLProfile
 
   protected def additionalSchemas: List[String] = List.empty

--- a/src/test/scala/e2e/MySqlSubsettingTest.scala
+++ b/src/test/scala/e2e/MySqlSubsettingTest.scala
@@ -1,0 +1,7 @@
+package e2e
+
+import util.db.MySqlDatabase
+
+abstract class MySqlSubsettingTest extends MySqlEnabledTest with SubsettingTest[MySqlDatabase] {
+
+}

--- a/src/test/scala/e2e/PostgresEnabledTest.scala
+++ b/src/test/scala/e2e/PostgresEnabledTest.scala
@@ -6,7 +6,7 @@ import util.db._
 import scala.sys.process._
 import scala.util.Properties
 
-abstract class PostgresEnabledTest extends DbEnabledTest[PostgreSQLDatabase] {
+abstract class PostgresEnabledTest extends DbEnabledTest[PostgresDatabase] {
   override protected val profile = slick.jdbc.PostgresProfile
 
   protected def testName: String
@@ -20,7 +20,7 @@ abstract class PostgresEnabledTest extends DbEnabledTest[PostgreSQLDatabase] {
     PostgresqlEndToEndTestUtil.createDb(dbs.targetAkkaStreams)
   }
 
-  override protected def dbs: DatabaseSet[PostgreSQLDatabase] = {
+  override protected def dbs: DatabaseSet[PostgresDatabase] = {
     val host = Properties.envOrElse("DB_SUBSETTER_POSTGRES_HOST", "localhost")
     val port = Ports.sharedPostgresPort
 
@@ -51,16 +51,16 @@ abstract class PostgresEnabledTest extends DbEnabledTest[PostgreSQLDatabase] {
 }
 
 object PostgresqlEndToEndTestUtil {
-  def buildDatabase(dbHost: String, dbPort: Int, dbName: String): PostgreSQLDatabase = {
-    new PostgreSQLDatabase(dbHost, dbPort, dbName)
+  def buildDatabase(dbHost: String, dbPort: Int, dbName: String): PostgresDatabase = {
+    new PostgresDatabase(dbHost, dbPort, dbName)
   }
 
-  def createDb(db: PostgreSQLDatabase): Unit = {
+  def createDb(db: PostgresDatabase): Unit = {
     s"dropdb --host ${db.host} --port ${db.port} --user postgres --if-exists ${db.name}".!!
     s"createdb --host ${db.host} --port ${db.port} --user postgres ${db.name}".!!
   }
 
-  def preSubsetDdlSync(origin: PostgreSQLDatabase, target: PostgreSQLDatabase): Unit = {
+  def preSubsetDdlSync(origin: PostgresDatabase, target: PostgresDatabase): Unit = {
     val exportCommand =
       s"pg_dump --host ${origin.host} --port ${origin.port} --user postgres --section=pre-data ${origin.name}"
 
@@ -70,7 +70,7 @@ object PostgresqlEndToEndTestUtil {
     (exportCommand #| importCommand).!!
   }
 
-  def postSubsetDdlSync(origin: PostgreSQLDatabase, target: PostgreSQLDatabase): Unit = {
+  def postSubsetDdlSync(origin: PostgresDatabase, target: PostgresDatabase): Unit = {
     val exportCommand =
       s"pg_dump --host ${origin.host} --port ${origin.port} --user postgres --section=post-data ${origin.name}"
 

--- a/src/test/scala/e2e/PostgresEnabledTest.scala
+++ b/src/test/scala/e2e/PostgresEnabledTest.scala
@@ -6,6 +6,9 @@ import util.db._
 import scala.sys.process._
 import scala.util.Properties
 
+/**
+  * A test which requires access to a running PostgreSQL database.
+  */
 abstract class PostgresEnabledTest extends DbEnabledTest[PostgresDatabase] {
   override protected val profile = slick.jdbc.PostgresProfile
 
@@ -43,11 +46,6 @@ abstract class PostgresEnabledTest extends DbEnabledTest[PostgresDatabase] {
     PostgresqlEndToEndTestUtil.preSubsetDdlSync(dbs.origin, dbs.targetSingleThreaded)
     PostgresqlEndToEndTestUtil.preSubsetDdlSync(dbs.origin, dbs.targetAkkaStreams)
   }
-
-  override protected def postSubset(): Unit = {
-    PostgresqlEndToEndTestUtil.postSubsetDdlSync(dbs.origin, dbs.targetSingleThreaded)
-    PostgresqlEndToEndTestUtil.postSubsetDdlSync(dbs.origin, dbs.targetAkkaStreams)
-  }
 }
 
 object PostgresqlEndToEndTestUtil {
@@ -70,13 +68,4 @@ object PostgresqlEndToEndTestUtil {
     (exportCommand #| importCommand).!!
   }
 
-  def postSubsetDdlSync(origin: PostgresDatabase, target: PostgresDatabase): Unit = {
-    val exportCommand =
-      s"pg_dump --host ${origin.host} --port ${origin.port} --user postgres --section=post-data ${origin.name}"
-
-    val importCommand =
-      s"psql --host ${target.host} --port ${target.port} --user postgres ${target.name} -v ON_ERROR_STOP=1"
-
-    (exportCommand #| importCommand).!!
-  }
 }

--- a/src/test/scala/e2e/PostgresEnabledTest.scala
+++ b/src/test/scala/e2e/PostgresEnabledTest.scala
@@ -6,7 +6,7 @@ import util.db._
 import scala.sys.process._
 import scala.util.Properties
 
-abstract class AbstractPostgresqlEndToEndTest extends AbstractEndToEndTest[PostgreSQLDatabase] {
+abstract class PostgresEnabledTest extends DbEnabledTest[PostgreSQLDatabase] {
   override protected val profile = slick.jdbc.PostgresProfile
 
   protected def testName: String

--- a/src/test/scala/e2e/PostgresSubsettingTest.scala
+++ b/src/test/scala/e2e/PostgresSubsettingTest.scala
@@ -1,0 +1,7 @@
+package e2e
+
+import util.db.PostgresDatabase
+
+abstract class PostgresSubsettingTest extends PostgresEnabledTest with SubsettingTest[PostgresDatabase] {
+
+}

--- a/src/test/scala/e2e/PostgresSubsettingTest.scala
+++ b/src/test/scala/e2e/PostgresSubsettingTest.scala
@@ -2,6 +2,23 @@ package e2e
 
 import util.db.PostgresDatabase
 
+import scala.sys.process._
+
 abstract class PostgresSubsettingTest extends PostgresEnabledTest with SubsettingTest[PostgresDatabase] {
 
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    postSubsetDdlSync(dbs.origin, dbs.targetSingleThreaded)
+    postSubsetDdlSync(dbs.origin, dbs.targetAkkaStreams)
+  }
+
+  private def postSubsetDdlSync(origin: PostgresDatabase, target: PostgresDatabase): Unit = {
+    val exportCommand =
+      s"pg_dump --host ${origin.host} --port ${origin.port} --user postgres --section=post-data ${origin.name}"
+
+    val importCommand =
+      s"psql --host ${target.host} --port ${target.port} --user postgres ${target.name} -v ON_ERROR_STOP=1"
+
+    (exportCommand #| importCommand).!!
+  }
 }

--- a/src/test/scala/e2e/SqlServerEnabledTest.scala
+++ b/src/test/scala/e2e/SqlServerEnabledTest.scala
@@ -6,6 +6,9 @@ import util.db._
 import scala.sys.process._
 import scala.util.Properties
 
+/**
+  * A test which requires access to a running Microsoft Sql Server database.
+  */
 abstract class SqlServerEnabledTest extends DbEnabledTest[SqlServerDatabase] {
   override protected val profile = slick.jdbc.SQLServerProfile
 
@@ -42,11 +45,6 @@ abstract class SqlServerEnabledTest extends DbEnabledTest[SqlServerDatabase] {
   override protected def prepareTargetDDL(): Unit = {
     s"./src/test/util/sync_sqlserver_origin_to_target.sh ${dbs.origin.host} ${dbs.origin.name} ${dbs.targetSingleThreaded.name}".!!
     s"./src/test/util/sync_sqlserver_origin_to_target.sh ${dbs.origin.host} ${dbs.origin.name} ${dbs.targetAkkaStreams.name}".!!
-  }
-
-  override protected def postSubset(): Unit = {
-    s"./src/test/util/sqlserver_post_subset.sh ${dbs.origin.host} ${dbs.targetSingleThreaded.name}".!!
-    s"./src/test/util/sqlserver_post_subset.sh ${dbs.origin.host} ${dbs.targetAkkaStreams.name}".!!
   }
 
   private def createEmptyDb(containerName: String, dbName: String): Unit = {

--- a/src/test/scala/e2e/SqlServerEnabledTest.scala
+++ b/src/test/scala/e2e/SqlServerEnabledTest.scala
@@ -6,7 +6,7 @@ import util.db._
 import scala.sys.process._
 import scala.util.Properties
 
-abstract class AbstractSqlServerEndToEndTest extends AbstractEndToEndTest[SqlServerDatabase] {
+abstract class SqlServerEnabledTest extends DbEnabledTest[SqlServerDatabase] {
   override protected val profile = slick.jdbc.SQLServerProfile
 
   protected def testName: String

--- a/src/test/scala/e2e/SqlServerSubsettingTest.scala
+++ b/src/test/scala/e2e/SqlServerSubsettingTest.scala
@@ -1,0 +1,7 @@
+package e2e
+
+import util.db.SqlServerDatabase
+
+abstract class SqlServerSubsettingTest extends SqlServerEnabledTest with SubsettingTest[SqlServerDatabase] {
+
+}

--- a/src/test/scala/e2e/SqlServerSubsettingTest.scala
+++ b/src/test/scala/e2e/SqlServerSubsettingTest.scala
@@ -2,6 +2,13 @@ package e2e
 
 import util.db.SqlServerDatabase
 
+import scala.sys.process._
+
 abstract class SqlServerSubsettingTest extends SqlServerEnabledTest with SubsettingTest[SqlServerDatabase] {
 
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    s"./src/test/util/sqlserver_post_subset.sh ${dbs.origin.host} ${dbs.targetSingleThreaded.name}".!!
+    s"./src/test/util/sqlserver_post_subset.sh ${dbs.origin.host} ${dbs.targetAkkaStreams.name}".!!
+  }
 }

--- a/src/test/scala/e2e/SubsettingTest.scala
+++ b/src/test/scala/e2e/SubsettingTest.scala
@@ -3,7 +3,11 @@ package e2e
 import trw.dbsubsetter.ApplicationRunner
 import util.db.Database
 
-
+/**
+  * A test mixin which runs subsetting in both single threaded mode and akka streams
+  * mode before starting to make assertions. Tests may then make assertions about
+  * the resulting target datasets.
+  */
 trait SubsettingTest[T <: Database] extends DbEnabledTest[T] {
 
   protected def programArgs: Array[String]
@@ -18,12 +22,12 @@ trait SubsettingTest[T <: Database] extends DbEnabledTest[T] {
     akkaStreamsRuntimeMillis = runSubsetInAkkaStreamsMode()
   }
 
+  // format: off
   protected def runSubsetInSingleThreadedMode(): Long = {
     val defaultArgs: Array[String] = Array(
       "--originDbConnStr", dbs.origin.connectionString,
       "--targetDbConnStr", dbs.targetSingleThreaded.connectionString,
       "--singleThreadedDebugMode"
-
     )
     val finalArgs: Array[String] = defaultArgs ++ programArgs
 
@@ -42,6 +46,7 @@ trait SubsettingTest[T <: Database] extends DbEnabledTest[T] {
 
     timedSubsetMilliseconds(finalArgs)
   }
+  // format: on
 
   private def timedSubsetMilliseconds(args: Array[String]): Long = {
     val start = System.nanoTime()

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestMySql.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.autoincrementingpk
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class AutoIncrementingPkTestMySql extends MySqlEnabledTest with AutoIncrementingPkTest {
+class AutoIncrementingPkTestMySql extends MySqlSubsettingTest with AutoIncrementingPkTest {
 
   override protected val programArgs = Array(
     "--schemas", "autoincrementing_pk",

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestMySql.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.autoincrementingpk
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class AutoIncrementingPkTestMySql extends AbstractMysqlEndToEndTest with AutoIncrementingPkTest {
+class AutoIncrementingPkTestMySql extends MySqlEnabledTest with AutoIncrementingPkTest {
 
   override protected val programArgs = Array(
     "--schemas", "autoincrementing_pk",

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestPostgreSQL.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.autoincrementingpk
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class AutoIncrementingPkTestPostgreSQL extends AbstractPostgresqlEndToEndTest with AutoIncrementingPkTest {
+class AutoIncrementingPkTestPostgreSQL extends PostgresEnabledTest with AutoIncrementingPkTest {
 
   override protected val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestPostgreSQL.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.autoincrementingpk
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class AutoIncrementingPkTestPostgreSQL extends PostgresEnabledTest with AutoIncrementingPkTest {
+class AutoIncrementingPkTestPostgreSQL extends PostgresSubsettingTest with AutoIncrementingPkTest {
 
   override protected val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestSqlServer.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.autoincrementingpk
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class AutoIncrementingPkTestSqlServer extends AbstractSqlServerEndToEndTest with AutoIncrementingPkTest {
+class AutoIncrementingPkTestSqlServer extends SqlServerEnabledTest with AutoIncrementingPkTest {
 
   override protected val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestSqlServer.scala
+++ b/src/test/scala/e2e/autoincrementingpk/AutoIncrementingPkTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.autoincrementingpk
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class AutoIncrementingPkTestSqlServer extends SqlServerEnabledTest with AutoIncrementingPkTest {
+class AutoIncrementingPkTestSqlServer extends SqlServerSubsettingTest with AutoIncrementingPkTest {
 
   override protected val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestMySql.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.basequeries
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class BaseQueriesTestMySql extends MySqlEnabledTest with BaseQueriesTest {
+class BaseQueriesTestMySql extends MySqlSubsettingTest with BaseQueriesTest {
 
   override protected val programArgs = Array(
     "--schemas", "base_queries",

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestMySql.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.basequeries
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class BaseQueriesTestMySql extends AbstractMysqlEndToEndTest with BaseQueriesTest {
+class BaseQueriesTestMySql extends MySqlEnabledTest with BaseQueriesTest {
 
   override protected val programArgs = Array(
     "--schemas", "base_queries",

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestPostgreSQL.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.basequeries
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class BaseQueriesTestPostgreSQL extends PostgresEnabledTest with BaseQueriesTest {
+class BaseQueriesTestPostgreSQL extends PostgresSubsettingTest with BaseQueriesTest {
 
   override protected val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestPostgreSQL.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.basequeries
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class BaseQueriesTestPostgreSQL extends AbstractPostgresqlEndToEndTest with BaseQueriesTest {
+class BaseQueriesTestPostgreSQL extends PostgresEnabledTest with BaseQueriesTest {
 
   override protected val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestSqlServer.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.basequeries
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class BaseQueriesTestSqlServer extends SqlServerEnabledTest with BaseQueriesTest {
+class BaseQueriesTestSqlServer extends SqlServerSubsettingTest with BaseQueriesTest {
 
   override protected val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/basequeries/BaseQueriesTestSqlServer.scala
+++ b/src/test/scala/e2e/basequeries/BaseQueriesTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.basequeries
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class BaseQueriesTestSqlServer extends AbstractSqlServerEndToEndTest with BaseQueriesTest {
+class BaseQueriesTestSqlServer extends SqlServerEnabledTest with BaseQueriesTest {
 
   override protected val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/circulardep/CircularDepTestMySql.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.circulardep
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class CircularDepTestMySql extends AbstractMysqlEndToEndTest with CircularDepTest {
+class CircularDepTestMySql extends MySqlEnabledTest with CircularDepTest {
 
   override val programArgs = Array(
     "--schemas", "circular_dep",

--- a/src/test/scala/e2e/circulardep/CircularDepTestMySql.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.circulardep
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class CircularDepTestMySql extends MySqlEnabledTest with CircularDepTest {
+class CircularDepTestMySql extends MySqlSubsettingTest with CircularDepTest {
 
   override val programArgs = Array(
     "--schemas", "circular_dep",

--- a/src/test/scala/e2e/circulardep/CircularDepTestPostgreSQL.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.circulardep
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class CircularDepTestPostgreSQL extends PostgresEnabledTest with CircularDepTest {
+class CircularDepTestPostgreSQL extends PostgresSubsettingTest with CircularDepTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/circulardep/CircularDepTestPostgreSQL.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.circulardep
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class CircularDepTestPostgreSQL extends AbstractPostgresqlEndToEndTest with CircularDepTest {
+class CircularDepTestPostgreSQL extends PostgresEnabledTest with CircularDepTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/circulardep/CircularDepTestSqlServer.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.circulardep
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class CircularDepTestSqlServer extends SqlServerEnabledTest with CircularDepTest {
+class CircularDepTestSqlServer extends SqlServerSubsettingTest with CircularDepTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/circulardep/CircularDepTestSqlServer.scala
+++ b/src/test/scala/e2e/circulardep/CircularDepTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.circulardep
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class CircularDepTestSqlServer extends AbstractSqlServerEndToEndTest with CircularDepTest {
+class CircularDepTestSqlServer extends SqlServerEnabledTest with CircularDepTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestMySql.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.compositekeys
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class CompositeKeysTestMySql extends AbstractMysqlEndToEndTest with CompositeKeysTest {
+class CompositeKeysTestMySql extends MySqlEnabledTest with CompositeKeysTest {
 
   override val programArgs = Array(
     "--schemas", "composite_keys",

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestMySql.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.compositekeys
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class CompositeKeysTestMySql extends MySqlEnabledTest with CompositeKeysTest {
+class CompositeKeysTestMySql extends MySqlSubsettingTest with CompositeKeysTest {
 
   override val programArgs = Array(
     "--schemas", "composite_keys",

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestPostgreSQL.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.compositekeys
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class CompositeKeysTestPostgreSQL extends AbstractPostgresqlEndToEndTest with CompositeKeysTest {
+class CompositeKeysTestPostgreSQL extends PostgresEnabledTest with CompositeKeysTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestPostgreSQL.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.compositekeys
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class CompositeKeysTestPostgreSQL extends PostgresEnabledTest with CompositeKeysTest {
+class CompositeKeysTestPostgreSQL extends PostgresSubsettingTest with CompositeKeysTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestSqlServer.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.compositekeys
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class CompositeKeysTestSqlServer extends SqlServerEnabledTest with CompositeKeysTest {
+class CompositeKeysTestSqlServer extends SqlServerSubsettingTest with CompositeKeysTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/compositekeys/CompositeKeysTestSqlServer.scala
+++ b/src/test/scala/e2e/compositekeys/CompositeKeysTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.compositekeys
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class CompositeKeysTestSqlServer extends AbstractSqlServerEndToEndTest with CompositeKeysTest {
+class CompositeKeysTestSqlServer extends SqlServerEnabledTest with CompositeKeysTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestMySql.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.crossschema
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class CrossSchemaTestMySql extends AbstractMysqlEndToEndTest with CrossSchemaTest {
+class CrossSchemaTestMySql extends MySqlEnabledTest with CrossSchemaTest {
 
   override protected val additionalSchemas: List[String] =
     List[String]("schema_1", "schema_2", "schema_3")

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestMySql.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.crossschema
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class CrossSchemaTestMySql extends MySqlEnabledTest with CrossSchemaTest {
+class CrossSchemaTestMySql extends MySqlSubsettingTest with CrossSchemaTest {
 
   override protected val additionalSchemas: List[String] =
     List[String]("schema_1", "schema_2", "schema_3")

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestPostgreSQL.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestPostgreSQL.scala
@@ -1,13 +1,13 @@
 package e2e.crossschema
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 import slick.dbio.DBIO
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class CrossSchemaTestPostgreSQL extends PostgresEnabledTest with CrossSchemaTest {
+class CrossSchemaTestPostgreSQL extends PostgresSubsettingTest with CrossSchemaTest {
 
   override val programArgs = Array(
     "--schemas", "schema_1, schema_2, schema_3",

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestPostgreSQL.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestPostgreSQL.scala
@@ -1,13 +1,13 @@
 package e2e.crossschema
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 import slick.dbio.DBIO
 import slick.jdbc.PostgresProfile.api._
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 
-class CrossSchemaTestPostgreSQL extends AbstractPostgresqlEndToEndTest with CrossSchemaTest {
+class CrossSchemaTestPostgreSQL extends PostgresEnabledTest with CrossSchemaTest {
 
   override val programArgs = Array(
     "--schemas", "schema_1, schema_2, schema_3",

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestSqlServer.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestSqlServer.scala
@@ -1,10 +1,10 @@
 package e2e.crossschema
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
 import scala.sys.process._
 
-class CrossSchemaTestSqlServer extends AbstractSqlServerEndToEndTest with CrossSchemaTest {
+class CrossSchemaTestSqlServer extends SqlServerEnabledTest with CrossSchemaTest {
 
   override protected val programArgs = Array(
     "--schemas", "schema_1, schema_2, schema_3",

--- a/src/test/scala/e2e/crossschema/CrossSchemaTestSqlServer.scala
+++ b/src/test/scala/e2e/crossschema/CrossSchemaTestSqlServer.scala
@@ -1,10 +1,10 @@
 package e2e.crossschema
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
 import scala.sys.process._
 
-class CrossSchemaTestSqlServer extends SqlServerEnabledTest with CrossSchemaTest {
+class CrossSchemaTestSqlServer extends SqlServerSubsettingTest with CrossSchemaTest {
 
   override protected val programArgs = Array(
     "--schemas", "schema_1, schema_2, schema_3",

--- a/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestMySql.scala
+++ b/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.fktononpk
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class ForeignKeyToNonPrimaryKeyTestMySql extends MySqlEnabledTest with ForeignKeyToNonPrimaryKeyTest {
+class ForeignKeyToNonPrimaryKeyTestMySql extends MySqlSubsettingTest with ForeignKeyToNonPrimaryKeyTest {
 
   override val programArgs = Array(
     "--schemas", "fk_reference_non_pk",

--- a/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestMySql.scala
+++ b/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.fktononpk
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class ForeignKeyToNonPrimaryKeyTestMySql extends AbstractMysqlEndToEndTest with ForeignKeyToNonPrimaryKeyTest {
+class ForeignKeyToNonPrimaryKeyTestMySql extends MySqlEnabledTest with ForeignKeyToNonPrimaryKeyTest {
 
   override val programArgs = Array(
     "--schemas", "fk_reference_non_pk",

--- a/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestPostgreSQL.scala
+++ b/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.fktononpk
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class ForeignKeyToNonPrimaryKeyTestPostgreSQL extends PostgresEnabledTest with ForeignKeyToNonPrimaryKeyTest {
+class ForeignKeyToNonPrimaryKeyTestPostgreSQL extends PostgresSubsettingTest with ForeignKeyToNonPrimaryKeyTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestPostgreSQL.scala
+++ b/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.fktononpk
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class ForeignKeyToNonPrimaryKeyTestPostgreSQL extends AbstractPostgresqlEndToEndTest with ForeignKeyToNonPrimaryKeyTest {
+class ForeignKeyToNonPrimaryKeyTestPostgreSQL extends PostgresEnabledTest with ForeignKeyToNonPrimaryKeyTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestSqlServer.scala
+++ b/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.fktononpk
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class ForeignKeyToNonPrimaryKeyTestSqlServer extends SqlServerEnabledTest with ForeignKeyToNonPrimaryKeyTest {
+class ForeignKeyToNonPrimaryKeyTestSqlServer extends SqlServerSubsettingTest with ForeignKeyToNonPrimaryKeyTest {
 
   override protected val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestSqlServer.scala
+++ b/src/test/scala/e2e/fktononpk/ForeignKeyToNonPrimaryKeyTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.fktononpk
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class ForeignKeyToNonPrimaryKeyTestSqlServer extends AbstractSqlServerEndToEndTest with ForeignKeyToNonPrimaryKeyTest {
+class ForeignKeyToNonPrimaryKeyTestSqlServer extends SqlServerEnabledTest with ForeignKeyToNonPrimaryKeyTest {
 
   override protected val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/missingfk/MissingFkTestMySql.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.missingfk
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class MissingFkTestMySql extends MySqlEnabledTest with MissingFkTest {
+class MissingFkTestMySql extends MySqlSubsettingTest with MissingFkTest {
 
   override val programArgs = Array(
     "--schemas", "missing_fk",

--- a/src/test/scala/e2e/missingfk/MissingFkTestMySql.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.missingfk
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class MissingFkTestMySql extends AbstractMysqlEndToEndTest with MissingFkTest {
+class MissingFkTestMySql extends MySqlEnabledTest with MissingFkTest {
 
   override val programArgs = Array(
     "--schemas", "missing_fk",

--- a/src/test/scala/e2e/missingfk/MissingFkTestPostgreSQL.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.missingfk
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class MissingFkTestPostgreSQL extends PostgresEnabledTest with MissingFkTest {
+class MissingFkTestPostgreSQL extends PostgresSubsettingTest with MissingFkTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/missingfk/MissingFkTestPostgreSQL.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.missingfk
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class MissingFkTestPostgreSQL extends AbstractPostgresqlEndToEndTest with MissingFkTest {
+class MissingFkTestPostgreSQL extends PostgresEnabledTest with MissingFkTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/missingfk/MissingFkTestSqlServer.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.missingfk
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class MissingFkTestSqlServer extends AbstractSqlServerEndToEndTest with MissingFkTest {
+class MissingFkTestSqlServer extends SqlServerEnabledTest with MissingFkTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/missingfk/MissingFkTestSqlServer.scala
+++ b/src/test/scala/e2e/missingfk/MissingFkTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.missingfk
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class MissingFkTestSqlServer extends SqlServerEnabledTest with MissingFkTest {
+class MissingFkTestSqlServer extends SqlServerSubsettingTest with MissingFkTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestMySql.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.mixedcase
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class MixedCaseTestMySql extends AbstractMysqlEndToEndTest with MixedCaseTest {
+class MixedCaseTestMySql extends MySqlEnabledTest with MixedCaseTest {
 
   override val programArgs = Array(
     "--schemas", "mIXED_case_DB",

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestMySql.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.mixedcase
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class MixedCaseTestMySql extends MySqlEnabledTest with MixedCaseTest {
+class MixedCaseTestMySql extends MySqlSubsettingTest with MixedCaseTest {
 
   override val programArgs = Array(
     "--schemas", "mIXED_case_DB",

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestPostgreSQL.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.mixedcase
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class MixedCaseTestPostgreSQL extends PostgresEnabledTest with MixedCaseTest {
+class MixedCaseTestPostgreSQL extends PostgresSubsettingTest with MixedCaseTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestPostgreSQL.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.mixedcase
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class MixedCaseTestPostgreSQL extends AbstractPostgresqlEndToEndTest with MixedCaseTest {
+class MixedCaseTestPostgreSQL extends PostgresEnabledTest with MixedCaseTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestSqlServer.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.mixedcase
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class MixedCaseTestSqlServer extends AbstractSqlServerEndToEndTest with MixedCaseTest {
+class MixedCaseTestSqlServer extends SqlServerEnabledTest with MixedCaseTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/mixedcase/MixedCaseTestSqlServer.scala
+++ b/src/test/scala/e2e/mixedcase/MixedCaseTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.mixedcase
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class MixedCaseTestSqlServer extends SqlServerEnabledTest with MixedCaseTest {
+class MixedCaseTestSqlServer extends SqlServerSubsettingTest with MixedCaseTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesTest.scala
@@ -2,13 +2,13 @@ package e2e.mysqldatatypes
 
 import java.io.File
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 import util.assertion.AssertionUtil
 import util.db.MySqlDatabase
 
 import scala.sys.process._
 
-class MySqlDataTypesTest extends AbstractMysqlEndToEndTest with AssertionUtil {
+class MySqlDataTypesTest extends MySqlEnabledTest with AssertionUtil {
   override protected val testName = "mysql_data_types"
 
   override protected val programArgs = Array(

--- a/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesTest.scala
+++ b/src/test/scala/e2e/mysqldatatypes/MySqlDataTypesTest.scala
@@ -2,13 +2,13 @@ package e2e.mysqldatatypes
 
 import java.io.File
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 import util.assertion.AssertionUtil
 import util.db.MySqlDatabase
 
 import scala.sys.process._
 
-class MySqlDataTypesTest extends MySqlEnabledTest with AssertionUtil {
+class MySqlDataTypesTest extends MySqlSubsettingTest with AssertionUtil {
   override protected val testName = "mysql_data_types"
 
   override protected val programArgs = Array(

--- a/src/test/scala/e2e/pgdatatypes/PostgreSQLDataTypesTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PostgreSQLDataTypesTest.scala
@@ -2,12 +2,12 @@ package e2e.pgdatatypes
 
 import java.io.File
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 import util.db.PostgresDatabase
 
 import scala.sys.process._
 
-class PostgreSQLDataTypesTest extends PostgresEnabledTest {
+class PostgreSQLDataTypesTest extends PostgresSubsettingTest {
   override protected val testName = "pg_data_types"
 
   override protected val programArgs = Array(

--- a/src/test/scala/e2e/pgdatatypes/PostgreSQLDataTypesTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PostgreSQLDataTypesTest.scala
@@ -2,12 +2,12 @@ package e2e.pgdatatypes
 
 import java.io.File
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.DbEnabledTest
 import util.db.PostgreSQLDatabase
 
 import scala.sys.process._
 
-class PostgreSQLDataTypesTest extends AbstractPostgresqlEndToEndTest {
+class PostgreSQLDataTypesTest extends DbEnabledTest {
   override protected val testName = "pg_data_types"
 
   override protected val programArgs = Array(

--- a/src/test/scala/e2e/pgdatatypes/PostgreSQLDataTypesTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PostgreSQLDataTypesTest.scala
@@ -3,7 +3,7 @@ package e2e.pgdatatypes
 import java.io.File
 
 import e2e.PostgresEnabledTest
-import util.db.PostgreSQLDatabase
+import util.db.PostgresDatabase
 
 import scala.sys.process._
 
@@ -44,7 +44,7 @@ class PostgreSQLDataTypesTest extends PostgresEnabledTest {
   }
 
   private def originPsqlCommand: String = {
-    val originDb: PostgreSQLDatabase = dbs.origin
+    val originDb: PostgresDatabase = dbs.origin
     s"psql --host ${originDb.host} --port ${originDb.port} --user postgres ${originDb.name}"
   }
 }

--- a/src/test/scala/e2e/pgdatatypes/PostgreSQLDataTypesTest.scala
+++ b/src/test/scala/e2e/pgdatatypes/PostgreSQLDataTypesTest.scala
@@ -2,12 +2,12 @@ package e2e.pgdatatypes
 
 import java.io.File
 
-import e2e.DbEnabledTest
+import e2e.PostgresEnabledTest
 import util.db.PostgreSQLDatabase
 
 import scala.sys.process._
 
-class PostgreSQLDataTypesTest extends DbEnabledTest {
+class PostgreSQLDataTypesTest extends PostgresEnabledTest {
   override protected val testName = "pg_data_types"
 
   override protected val programArgs = Array(

--- a/src/test/scala/e2e/pktypes/PkTypesTestMySql.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.pktypes
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class PkTypesTestMySql extends AbstractMysqlEndToEndTest with PkTypesTest {
+class PkTypesTestMySql extends MySqlEnabledTest with PkTypesTest {
 
   override def expectedChar10Ids = Seq[String](" four", "two")
 

--- a/src/test/scala/e2e/pktypes/PkTypesTestMySql.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.pktypes
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class PkTypesTestMySql extends MySqlEnabledTest with PkTypesTest {
+class PkTypesTestMySql extends MySqlSubsettingTest with PkTypesTest {
 
   override def expectedChar10Ids = Seq[String](" four", "two")
 

--- a/src/test/scala/e2e/pktypes/PkTypesTestPostgreSQL.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.pktypes
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class PkTypesTestPostgreSQL extends AbstractPostgresqlEndToEndTest with PkTypesTest {
+class PkTypesTestPostgreSQL extends PostgresEnabledTest with PkTypesTest {
 
   override protected val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/pktypes/PkTypesTestPostgreSQL.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.pktypes
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class PkTypesTestPostgreSQL extends PostgresEnabledTest with PkTypesTest {
+class PkTypesTestPostgreSQL extends PostgresSubsettingTest with PkTypesTest {
 
   override protected val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/pktypes/PkTypesTestSqlServer.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestSqlServer.scala
@@ -2,9 +2,9 @@ package e2e.pktypes
 
 import java.util.UUID
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class PkTypesTestSqlServer extends SqlServerEnabledTest with PkTypesTest {
+class PkTypesTestSqlServer extends SqlServerSubsettingTest with PkTypesTest {
 
   override def expectedByteIds = super.expectedByteIds.filterNot(_ == -128)
 

--- a/src/test/scala/e2e/pktypes/PkTypesTestSqlServer.scala
+++ b/src/test/scala/e2e/pktypes/PkTypesTestSqlServer.scala
@@ -2,9 +2,9 @@ package e2e.pktypes
 
 import java.util.UUID
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class PkTypesTestSqlServer extends AbstractSqlServerEndToEndTest with PkTypesTest {
+class PkTypesTestSqlServer extends SqlServerEnabledTest with PkTypesTest {
 
   override def expectedByteIds = super.expectedByteIds.filterNot(_ == -128)
 

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestMySql.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.selfreferencing
 
-import e2e.AbstractMysqlEndToEndTest
+import e2e.MySqlEnabledTest
 
-class SelfReferencingTestMySql extends AbstractMysqlEndToEndTest with SelfReferencingTest {
+class SelfReferencingTestMySql extends MySqlEnabledTest with SelfReferencingTest {
 
   override val programArgs = Array(
     "--schemas", "self_referencing",

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestMySql.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestMySql.scala
@@ -1,8 +1,8 @@
 package e2e.selfreferencing
 
-import e2e.MySqlEnabledTest
+import e2e.MySqlSubsettingTest
 
-class SelfReferencingTestMySql extends MySqlEnabledTest with SelfReferencingTest {
+class SelfReferencingTestMySql extends MySqlSubsettingTest with SelfReferencingTest {
 
   override val programArgs = Array(
     "--schemas", "self_referencing",

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestPostgreSQL.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.selfreferencing
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 
-class SelfReferencingTestPostgreSQL extends PostgresEnabledTest with SelfReferencingTest {
+class SelfReferencingTestPostgreSQL extends PostgresSubsettingTest with SelfReferencingTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestPostgreSQL.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestPostgreSQL.scala
@@ -1,8 +1,8 @@
 package e2e.selfreferencing
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 
-class SelfReferencingTestPostgreSQL extends AbstractPostgresqlEndToEndTest with SelfReferencingTest {
+class SelfReferencingTestPostgreSQL extends PostgresEnabledTest with SelfReferencingTest {
 
   override val programArgs = Array(
     "--schemas", "public",

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestSqlServer.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.selfreferencing
 
-import e2e.SqlServerEnabledTest
+import e2e.SqlServerSubsettingTest
 
-class SelfReferencingTestSqlServer extends SqlServerEnabledTest with SelfReferencingTest {
+class SelfReferencingTestSqlServer extends SqlServerSubsettingTest with SelfReferencingTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/e2e/selfreferencing/SelfReferencingTestSqlServer.scala
+++ b/src/test/scala/e2e/selfreferencing/SelfReferencingTestSqlServer.scala
@@ -1,8 +1,8 @@
 package e2e.selfreferencing
 
-import e2e.AbstractSqlServerEndToEndTest
+import e2e.SqlServerEnabledTest
 
-class SelfReferencingTestSqlServer extends AbstractSqlServerEndToEndTest with SelfReferencingTest {
+class SelfReferencingTestSqlServer extends SqlServerEnabledTest with SelfReferencingTest {
 
   override val programArgs = Array(
     "--schemas", "dbo",

--- a/src/test/scala/load/LoadTest.scala
+++ b/src/test/scala/load/LoadTest.scala
@@ -1,11 +1,10 @@
 package load
 
-import e2e.DbEnabledTest
+import e2e.SubsettingTest
 import util.db.Database
-import util.runner.TestSubsetRunner
 
-/*
- * A load test is an AbstractEndToEndTest with two extra capabilities:
+/**
+ * A load test is a `SubsettingTest` with two extra capabilities:
  *   1. Track how long a subsetting run took and assert that it was within expected limits
  *   2. Quickly load data into the origin DB on the first run and then keep the container there for faster runs later
  *
@@ -13,23 +12,11 @@ import util.runner.TestSubsetRunner
  * way. Because of how messy the implementation of (2) is at the moment, only Postgres load tests work at the moment, and
  * their MySql and SqlServer counterparts are commented out. This is a definite area for future refactoring.
  */
-trait LoadTest[T <: Database] { this: DbEnabledTest[T] =>
+trait LoadTest[T <: Database] { this: SubsettingTest[T] =>
 
   protected def singleThreadedRuntimeLimitMillis: Long
 
   protected def akkaStreamsRuntimeLimitMillis: Long
-
-  private var singleThreadedRuntimeMillis: Long = _
-
-  private var akkaStreamsRuntimeMillis: Long = _
-
-  override protected def runSubsetInSingleThreadedMode(): Unit = {
-    singleThreadedRuntimeMillis = TestSubsetRunner.runSubsetInSingleThreadedMode(dbs, programArgs)
-  }
-
-  override protected def runSubsetInAkkaStreamsMode(): Unit = {
-    akkaStreamsRuntimeMillis = TestSubsetRunner.runSubsetInAkkaStreamsMode(dbs, programArgs)
-  }
 
   test("Check that single threaded runtime did not significantly increase") {
     assert(singleThreadedRuntimeMillis < singleThreadedRuntimeLimitMillis)

--- a/src/test/scala/load/LoadTest.scala
+++ b/src/test/scala/load/LoadTest.scala
@@ -4,15 +4,15 @@ import e2e.SubsettingTest
 import util.db.Database
 
 /**
- * A load test is a `SubsettingTest` with two extra capabilities:
- *   1. Track how long a subsetting run took and assert that it was within expected limits
- *   2. Quickly load data into the origin DB on the first run and then keep the container there for faster runs later
- *
- * This trait just handles (1) right now, and (2) is handled in concrete test classes in a very quickly-hacked-together
- * way. Because of how messy the implementation of (2) is at the moment, only Postgres load tests work at the moment, and
- * their MySql and SqlServer counterparts are commented out. This is a definite area for future refactoring.
- */
-trait LoadTest[T <: Database] { this: SubsettingTest[T] =>
+  * A load test is a `SubsettingTest` with two extra capabilities:
+  *   1. Assert that subsetting runtimes were within some pre-defined, expected limits
+  *   2. Quickly load data into the origin DB on the first run and then keep the container there for faster runs later
+  *
+  * This trait just handles (1) right now, and (2) is handled in concrete test classes in a very quickly-hacked-together
+  * way. Because of how messy the implementation of (2) is at the moment, only Postgres load tests work at the moment, and
+  * their MySql and SqlServer counterparts are commented out. This is a definite area for future refactoring.
+  */
+trait LoadTest[T <: Database] extends SubsettingTest[T] {
 
   protected def singleThreadedRuntimeLimitMillis: Long
 

--- a/src/test/scala/load/LoadTest.scala
+++ b/src/test/scala/load/LoadTest.scala
@@ -1,6 +1,6 @@
 package load
 
-import e2e.AbstractEndToEndTest
+import e2e.DbEnabledTest
 import util.db.Database
 import util.runner.TestSubsetRunner
 
@@ -13,7 +13,7 @@ import util.runner.TestSubsetRunner
  * way. Because of how messy the implementation of (2) is at the moment, only Postgres load tests work at the moment, and
  * their MySql and SqlServer counterparts are commented out. This is a definite area for future refactoring.
  */
-trait LoadTest[T <: Database] { this: AbstractEndToEndTest[T] =>
+trait LoadTest[T <: Database] { this: DbEnabledTest[T] =>
 
   protected def singleThreadedRuntimeLimitMillis: Long
 

--- a/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
+++ b/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
@@ -3,7 +3,7 @@ package load.physics
 import java.io._
 import java.sql.{Connection, DriverManager, PreparedStatement, ResultSet}
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 import org.postgresql.copy.CopyManager
 import org.postgresql.core.BaseConnection
 import slick.jdbc.PostgresProfile.api._
@@ -52,7 +52,7 @@ import scala.concurrent.{Await, Future}
  *   Bulk Copy:         49  Seconds
 
  */
-class InsertBenchmarkPostgreSQL extends AbstractPostgresqlEndToEndTest {
+class InsertBenchmarkPostgreSQL extends PostgresEnabledTest {
 
   override protected def testName: String = "insert_benchmark"
 

--- a/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
+++ b/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
@@ -15,8 +15,6 @@ import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.Duration
 import scala.concurrent.{Await, Future}
 
-
-
 /*
  * This is a benchmark to find out what the fastest way to insert large volumes of data into Postgres is.
  * This is a very hacky extension of EndToEndTest class, and as benchmarks go it is not carefully controlled.
@@ -107,12 +105,6 @@ class InsertBenchmarkPostgreSQL extends PostgresEnabledTest {
 
     Await.ready(targetSingleThreadedSlick.run(createTableStatements), Duration.Inf)
   }
-
-  override protected def runSubsetInSingleThreadedMode(): Unit = {}
-
-  override protected def runSubsetInAkkaStreamsMode(): Unit = {}
-
-  override protected def postSubset(): Unit = {}
 
   test("JDBC Batch Insert 100 Rows At A Time") {
     jdbcBatchFullFlow("jdbc_batch_100", 100)
@@ -256,7 +248,6 @@ class InsertBenchmarkPostgreSQL extends PostgresEnabledTest {
     val originCopyManager: CopyManager = new CopyManager(originJdbcConnection.asInstanceOf[BaseConnection])
     val targetCopyManager: CopyManager = new CopyManager(targetJdbcConnection.asInstanceOf[BaseConnection])
 
-
     def makeBulkCopyIdString(fromIdInclusive: Int, endIdInclusive: Int): String = {
       val idValues = (fromIdInclusive to endIdInclusive).mkString(",")
       s"COPY (select * from quantum_data where id in ($idValues)) TO STDOUT (FORMAT BINARY)"
@@ -345,7 +336,8 @@ class InsertBenchmarkPostgreSQL extends PostgresEnabledTest {
   }
 
   private[this] lazy val targetJdbcConnection: Connection = {
-    val connectionString = s"jdbc:postgresql://localhost:${dbs.targetSingleThreaded.port}/${dbs.targetSingleThreaded.name}?user=postgres"
+    val connectionString =
+      s"jdbc:postgresql://localhost:${dbs.targetSingleThreaded.port}/${dbs.targetSingleThreaded.name}?user=postgres"
     val connection: Connection = DriverManager.getConnection(connectionString)
     connection.setAutoCommit(false)
     connection

--- a/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
+++ b/src/test/scala/load/physics/InsertBenchmarkPostgreSQL.scala
@@ -9,7 +9,7 @@ import org.postgresql.core.BaseConnection
 import slick.jdbc.PostgresProfile.api._
 import slick.sql.SqlAction
 import trw.dbsubsetter.db.Row
-import util.db.{DatabaseSet, PostgreSQLDatabase}
+import util.db.{DatabaseSet, PostgresDatabase}
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.Duration
@@ -60,12 +60,12 @@ class InsertBenchmarkPostgreSQL extends PostgresEnabledTest {
 
   override protected def createOriginDatabase(): Unit = {}
 
-  override protected def dbs: DatabaseSet[PostgreSQLDatabase] = {
+  override protected def dbs: DatabaseSet[PostgresDatabase] = {
     val defaults = super.dbs
 
-    val originDb = new PostgreSQLDatabase("localhost", ???, "physics_db")
+    val originDb = new PostgresDatabase("localhost", ???, "physics_db")
 
-    new DatabaseSet[PostgreSQLDatabase](
+    new DatabaseSet[PostgresDatabase](
       originDb,
       defaults.targetSingleThreaded,
       defaults.targetAkkaStreams

--- a/src/test/scala/load/physics/PhysicsTestPostgreSQL.scala
+++ b/src/test/scala/load/physics/PhysicsTestPostgreSQL.scala
@@ -1,6 +1,6 @@
 //package load.physics
 //
-//import e2e.{AbstractPostgresqlEndToEndTest, PostgresqlEndToEndTestUtil, SharedTestContainers}
+//import e2e.{PostgresEnabledTest, PostgresqlEndToEndTestUtil, SharedTestContainers}
 //import load.LoadTest
 //import util.Ports
 //import util.db.{DatabaseSet, PostgreSQLContainer, PostgreSQLDatabase}
@@ -8,7 +8,7 @@
 //
 //import scala.sys.process._
 //
-//class PhysicsTestPostgreSQL extends AbstractPostgresqlEndToEndTest with LoadTest[PostgreSQLDatabase] with PhysicsTest {
+//class PhysicsTestPostgreSQL extends PostgresEnabledTest with LoadTest[PostgreSQLDatabase] with PhysicsTest {
 //  override val singleThreadedRuntimeLimitMillis: Long = 13000000 // 3.6 hours
 //
 //  override val akkaStreamsRuntimeLimitMillis: Long = 2700000 // 45 minutes

--- a/src/test/scala/load/schooldb/SchoolDbTestMySql.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestMySql.scala
@@ -1,12 +1,12 @@
 //package load.schooldb
 //
-//import e2e.{AbstractMysqlEndToEndTest, MysqlEndToEndTestUtil}
+//import e2e.{MySqlEnabledTest, MysqlEndToEndTestUtil}
 //import load.LoadTest
 //import util.db.MySqlDatabase
 //
 //import scala.sys.process._
 //
-//class SchoolDbTestMySql extends AbstractMysqlEndToEndTest with LoadTest[MySqlDatabase] with SchoolDbTest {
+//class SchoolDbTestMySql extends MySqlEnabledTest with LoadTest[MySqlDatabase] with SchoolDbTest {
 //
 //  override val singleThreadedRuntimeLimitMillis: Long = 1150000
 //

--- a/src/test/scala/load/schooldb/SchoolDbTestPostgreSQL.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestPostgreSQL.scala
@@ -51,16 +51,13 @@ class SchoolDbTestPostgreSQL extends PostgresSubsettingTest with LoadTest[Postgr
     }
   }
 
+  // format: off
   override protected val programArgs = Array(
-    "--schemas",
-    "school_db,Audit",
-    "--baseQuery",
-    "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",
-    "--baseQuery",
-    "school_db.standalone_table ::: id < 4 ::: includeChildren",
-    "--excludeColumns",
-    "school_db.schools(mascot)",
-    "--excludeTable",
-    "school_db.empty_table_2"
+    "--schemas", "school_db,Audit",
+    "--baseQuery", "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",
+    "--baseQuery", "school_db.standalone_table ::: id < 4 ::: includeChildren",
+    "--excludeColumns", "school_db.schools(mascot)",
+    "--excludeTable", "school_db.empty_table_2"
   )
+  // format: on
 }

--- a/src/test/scala/load/schooldb/SchoolDbTestPostgreSQL.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestPostgreSQL.scala
@@ -1,6 +1,6 @@
 package load.schooldb
 
-import e2e.AbstractPostgresqlEndToEndTest
+import e2e.PostgresEnabledTest
 import load.LoadTest
 import slick.dbio.DBIO
 import slick.jdbc.PostgresProfile.api._
@@ -10,7 +10,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.sys.process._
 
-class SchoolDbTestPostgreSQL extends AbstractPostgresqlEndToEndTest with LoadTest[PostgreSQLDatabase] with SchoolDbTest {
+class SchoolDbTestPostgreSQL extends PostgresEnabledTest with LoadTest[PostgreSQLDatabase] with SchoolDbTest {
 
   /*
    * These values are configured for the Drone CI environment and are supposed to be pretty lenient,

--- a/src/test/scala/load/schooldb/SchoolDbTestPostgreSQL.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestPostgreSQL.scala
@@ -4,13 +4,13 @@ import e2e.PostgresEnabledTest
 import load.LoadTest
 import slick.dbio.DBIO
 import slick.jdbc.PostgresProfile.api._
-import util.db.PostgreSQLDatabase
+import util.db.PostgresDatabase
 
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.sys.process._
 
-class SchoolDbTestPostgreSQL extends PostgresEnabledTest with LoadTest[PostgreSQLDatabase] with SchoolDbTest {
+class SchoolDbTestPostgreSQL extends PostgresEnabledTest with LoadTest[PostgresDatabase] with SchoolDbTest {
 
   /*
    * These values are configured for the Drone CI environment and are supposed to be pretty lenient,

--- a/src/test/scala/load/schooldb/SchoolDbTestPostgreSQL.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestPostgreSQL.scala
@@ -1,6 +1,6 @@
 package load.schooldb
 
-import e2e.PostgresEnabledTest
+import e2e.PostgresSubsettingTest
 import load.LoadTest
 import slick.dbio.DBIO
 import slick.jdbc.PostgresProfile.api._
@@ -10,7 +10,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.sys.process._
 
-class SchoolDbTestPostgreSQL extends PostgresEnabledTest with LoadTest[PostgresDatabase] with SchoolDbTest {
+class SchoolDbTestPostgreSQL extends PostgresSubsettingTest with LoadTest[PostgresDatabase] with SchoolDbTest {
 
   /*
    * These values are configured for the Drone CI environment and are supposed to be pretty lenient,
@@ -22,11 +22,11 @@ class SchoolDbTestPostgreSQL extends PostgresEnabledTest with LoadTest[PostgresD
   override val akkaStreamsRuntimeLimitMillis: Long = 20000 // 20 seconds
 
   /*
-    * Only to be used when manually changing the origin db definition. In this case, the origin DB needs
-    * to be completely rebuilt from scratch using Slick definitions, as opposed to being efficiently
-    * loaded from an existing dump file. Only set this to `true` if you really know what you are doing, and
-    * if you are prepared to make sure the dump file stored in S3 gets updated to your latest version.
-    */
+   * Only to be used when manually changing the origin db definition. In this case, the origin DB needs
+   * to be completely rebuilt from scratch using Slick definitions, as opposed to being efficiently
+   * loaded from an existing dump file. Only set this to `true` if you really know what you are doing, and
+   * if you are prepared to make sure the dump file stored in S3 gets updated to your latest version.
+   */
   private val updateOriginDb: Boolean = false
 
   override protected def prepareOriginDDL(): Unit = {
@@ -47,15 +47,20 @@ class SchoolDbTestPostgreSQL extends PostgresEnabledTest with LoadTest[PostgresD
   override protected def prepareOriginDML(): Unit = {
     (updateOriginDb) match {
       case (false) => // No action necessary (already done in prepareOriginDDL)
-      case (true) => super.prepareOriginDML() // We have to populate it from scratch
+      case (true)  => super.prepareOriginDML() // We have to populate it from scratch
     }
   }
 
   override protected val programArgs = Array(
-    "--schemas", "school_db,Audit",
-    "--baseQuery", "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",
-    "--baseQuery", "school_db.standalone_table ::: id < 4 ::: includeChildren",
-    "--excludeColumns", "school_db.schools(mascot)",
-    "--excludeTable", "school_db.empty_table_2"
+    "--schemas",
+    "school_db,Audit",
+    "--baseQuery",
+    "school_db.Students ::: student_id % 100 = 0 ::: includeChildren",
+    "--baseQuery",
+    "school_db.standalone_table ::: id < 4 ::: includeChildren",
+    "--excludeColumns",
+    "school_db.schools(mascot)",
+    "--excludeTable",
+    "school_db.empty_table_2"
   )
 }

--- a/src/test/scala/load/schooldb/SchoolDbTestSqlServer.scala
+++ b/src/test/scala/load/schooldb/SchoolDbTestSqlServer.scala
@@ -1,12 +1,12 @@
 //package load.schooldb
 //
-//import e2e.AbstractSqlServerEndToEndTest
+//import e2e.SqlServerEnabledTest
 //import load.LoadTest
 //import util.db.SqlServerDatabase
 //
 //import scala.sys.process._
 //
-//class SchoolDbTestSqlServer extends AbstractSqlServerEndToEndTest with LoadTest[SqlServerDatabase] with SchoolDbTest {
+//class SchoolDbTestSqlServer extends SqlServerEnabledTest with LoadTest[SqlServerDatabase] with SchoolDbTest {
 //
 //  override val singleThreadedRuntimeLimitMillis: Long = 110000
 //

--- a/src/test/scala/util/db/Database.scala
+++ b/src/test/scala/util/db/Database.scala
@@ -10,7 +10,7 @@ class MySqlDatabase(val host: String, val port: Int, val name: String) extends D
   override def connectionString: String = s"jdbc:mysql://$host:$port/$name?user=root&useSSL=false&rewriteBatchedStatements=true"
 }
 
-class PostgreSQLDatabase(val host: String, val port: Int, val name: String) extends Database {
+class PostgresDatabase(val host: String, val port: Int, val name: String) extends Database {
   override def connectionString: String = s"jdbc:postgresql://$host:$port/$name?user=postgres"
 }
 


### PR DESCRIPTION
Refactor tests to allow for a database to be running next to a test, without necessarily requiring a full, successful subset to happen. This will help test DB schema validations errors, where we intend for the subset to fail early and not complete.