### PR TITLE
Replace deprecated scala.App

### DIFF
--- a/src/main/scala/trw/dbsubsetter/Application.scala
+++ b/src/main/scala/trw/dbsubsetter/Application.scala
@@ -1,11 +1,15 @@
 package trw.dbsubsetter
 
-object Application extends App {
-  ApplicationRunner.run(args) match {
-    case Success =>
-      System.exit(0)
-    case FailedToStart(message) =>
-      System.err.println("DBSubsetter failed to start. " + message)
-      System.exit(1)
+object Application {
+
+  def main(args: Array[String]): Unit = {
+    ApplicationRunner.run(args) match {
+      case Success =>
+        System.exit(0)
+      case FailedToStart(message) =>
+        System.err.println("DBSubsetter failed to start. " + message)
+        System.exit(1)
+    }
   }
+
 }

--- a/src/main/scala/trw/dbsubsetter/ApplicationRunner.scala
+++ b/src/main/scala/trw/dbsubsetter/ApplicationRunner.scala
@@ -3,12 +3,6 @@ package trw.dbsubsetter
 import trw.dbsubsetter.DbSubsetter.{FailedValidation, SubsetCompletedSuccessfully}
 import trw.dbsubsetter.config._
 
-/**
-  * Provides a very thin layer underneath the real Application object. Tests will
-  * call this object rather than calling the real Application object. This is because
-  * the real Application object appears to have some non-threadsafe behavior which
-  * can cause tests to fail nondeterministically when executed in parallel.
-  */
 object ApplicationRunner {
   def run(args: Array[String]): ApplicationRunResult = {
     CommandLineParser.parser.parse(args, CommandLineArgs()) match {


### PR DESCRIPTION
Per https://github.com/alexandru/scala-best-practices/blob/master/sections/2-language-rules.md#222-should-not-use-scalaapp