### PR TITLE
Allow load test comparisons

### DIFF
--- a/load-test/apply.sh
+++ b/load-test/apply.sh
@@ -12,4 +12,7 @@ docker run \
   --volume ~/.aws:/root/.aws \
   --workdir /tf \
   hashicorp/terraform:0.13.4 \
-  apply -auto-approve
+  apply \
+  -auto-approve \
+  -var="old-commit=$1" \
+  -var="new-commit=$2"

--- a/load-test/load-test.tf
+++ b/load-test/load-test.tf
@@ -11,6 +11,14 @@ terraform {
   }
 }
 
+variable "old-commit" {
+  type = string
+}
+
+variable "new-commit" {
+  type = string
+}
+
 data "template_file" "ssh-public-key" {
   template = file("./load-test.pem.pub")
 }
@@ -23,6 +31,8 @@ data "template_file" "provision-target" {
   template = file("./provision-target.sh")
   vars = {
     pg-origin-ip = aws_instance.pg-origin.private_ip
+    old-commit = var.old-commit
+    new-commit = var.new-commit
   }
 }
 

--- a/load-test/provision-target.sh
+++ b/load-test/provision-target.sh
@@ -56,11 +56,17 @@ rm /load-test/sbt.tgz
 #
 # Build DBSubsetter
 #
-wget --quiet -O /load-test/DBSubsetter.tar.gz https://github.com/bluerogue251/DBSubsetter/archive/b5d7570.tar.gz
-tar xzf /load-test/DBSubsetter.tar.gz --directory=/load-test
-rm /load-test/DBSubsetter.tar.gz
-cd /load-test/DBSubsetter-*
-./../sbt/bin/sbt --java-home /load-test/jdk8 'set assemblyOutputPath in assembly := new File("/load-test/DBSubsetter.jar")' assembly
+build_jar() {
+  wget --quiet -O /load-test/DBSubsetter-"$1".tar.gz https://github.com/bluerogue251/DBSubsetter/archive/"$1".tar.gz
+  wget --quiet -O /load-test/DBSubsetter-"$1".tar.gz https://github.com/bluerogue251/DBSubsetter/archive/"$1".tar.gz
+  tar xzf /load-test/DBSubsetter-"$1".tar.gz --directory=/load-test
+  rm /load-test/DBSubsetter-"$1".tar.gz
+  cd /load-test/DBSubsetter-"$1"*
+  ./../sbt/bin/sbt --java-home /load-test/jdk8 'set assemblyOutputPath in assembly := new File("/load-test/DBSubsetter'"$1"'.jar")' assembly
+}
+build_jar "${old-commit}"
+build_jar "${new-commit}"
+
 
 #
 # Wait for origin school_db to be ready
@@ -94,7 +100,7 @@ run_school_db_load_test() {
   sudo -u postgres createdb school_db
   sudo -u postgres psql --quiet --dbname school_db < /load-test/school-db-pre.sql
   echo "Running school_db load test"
-  /load-test/jdk8/bin/java -Xmx2G -jar /load-test/DBSubsetter.jar \
+  /load-test/jdk8/bin/java -Xmx2G -jar /load-test/DBSubsetter-"$1".jar \
     --originDbConnStr "jdbc:postgresql://${pg-origin-ip}:5432/school_db?user=loadtest&password=load-test-pw" \
     --targetDbConnStr "jdbc:postgresql://localhost:5432/school_db?user=loadtest&password=load-test-pw" \
     --keyCalculationDbConnectionCount 6 \
@@ -110,10 +116,16 @@ run_school_db_load_test() {
 }
 
 #
-# Run school_db load test twice
+# Run school_db load test three times for each commit
 #
-run_school_db_load_test
-run_school_db_load_test
+run_school_db_load_test "${old-commit}"
+run_school_db_load_test "${new-commit}"
+sleep 120
+run_school_db_load_test "${old-commit}"
+run_school_db_load_test "${new-commit}"
+sleep 120
+run_school_db_load_test "${old-commit}"
+run_school_db_load_test "${new-commit}"
 
 #
 # Signal school_db load test is complete
@@ -156,7 +168,7 @@ run_physics_db_load_test() {
   sudo -u postgres createdb physics_db
   sudo -u postgres psql --quiet --dbname physics_db < /load-test/physics-db-pre.sql
   echo "Running physics_db load test"
-  /load-test/jdk8/bin/java -Xmx2G -jar /load-test/DBSubsetter.jar \
+  /load-test/jdk8/bin/java -Xmx2G -jar /load-test/DBSubsetter-"$1".jar \
     --originDbConnStr "jdbc:postgresql://${pg-origin-ip}:5432/physics_db?user=loadtest&password=load-test-pw" \
     --targetDbConnStr "jdbc:postgresql://localhost:5432/physics_db?user=loadtest&password=load-test-pw" \
     --keyCalculationDbConnectionCount 6 \
@@ -168,11 +180,11 @@ run_physics_db_load_test() {
 }
 
 #
-# Run both school_db and physics_db load tests twice
-# (repeating school_db to make its graphs closer in Grafana)
+# Run physics_db load test three times for each commit
 #
-run_school_db_load_test
-run_school_db_load_test
-sleep 600 # Sleep 10 minutes to visually separate the graphs
-run_physics_db_load_test
-run_physics_db_load_test
+run_physics_db_load_test "${old-commit}"
+run_physics_db_load_test "${new-commit}"
+run_physics_db_load_test "${old-commit}"
+run_physics_db_load_test "${new-commit}"
+run_physics_db_load_test "${old-commit}"
+run_physics_db_load_test "${new-commit}"

--- a/load-test/provision-target.sh
+++ b/load-test/provision-target.sh
@@ -57,12 +57,13 @@ rm /load-test/sbt.tgz
 # Build DBSubsetter
 #
 build_jar() {
+  echo "Building DBSubsetter-$1.jar"
   wget --quiet -O /load-test/DBSubsetter-"$1".tar.gz https://github.com/bluerogue251/DBSubsetter/archive/"$1".tar.gz
   wget --quiet -O /load-test/DBSubsetter-"$1".tar.gz https://github.com/bluerogue251/DBSubsetter/archive/"$1".tar.gz
   tar xzf /load-test/DBSubsetter-"$1".tar.gz --directory=/load-test
   rm /load-test/DBSubsetter-"$1".tar.gz
   cd /load-test/DBSubsetter-"$1"*
-  ./../sbt/bin/sbt --java-home /load-test/jdk8 'set assemblyOutputPath in assembly := new File("/load-test/DBSubsetter'"$1"'.jar")' assembly
+  ./../sbt/bin/sbt --java-home /load-test/jdk8 'set assemblyOutputPath in assembly := new File("/load-test/DBSubsetter-'"$1"'.jar")' assembly
 }
 build_jar "${old-commit}"
 build_jar "${new-commit}"

--- a/run-load-test.sh
+++ b/run-load-test.sh
@@ -9,6 +9,10 @@
 # 2) AWS account credentials stored at ~/.aws/credentials
 #    https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html
 #
+# Input Arguments:
+# $1 The git commit hash of the old code to use as the baseline for comparisons
+# $2 The git commit hash of the new code to test and compare to the baseline
+#
 
 echo "Creating SSH Key (if not exists)"
 echo "n" | ssh-keygen -q -N "" -f load-test/load-test.pem -C "load-test@example.com"
@@ -21,7 +25,8 @@ echo "Initializing Terraform"
 printf "\n\n"
 
 echo "Spinning up load test infrastructure"
-./load-test/apply.sh
+./load-test/apply.sh "$1" "$2"
+
 printf "\n\n"
 
-echo "View results on the monitor instance's Grafana at http://monitor-ip:3000"
+echo "View results on the monitor instance's Grafana at http://<monitor-ip>:3000"


### PR DESCRIPTION
Load tests now accept two git commit hashes as arguments. The load test gets run multiple times with each commit hash. Typically, the first commit should be some "known good" version of DBSubsetter, and the second commit should be some "new version under test." DBSubsetter developers can then compare the load test results across the two commits to check for performance regressions.