### PR TITLE
Remove index from foreign key

### DIFF
--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -1,26 +1,28 @@
 package trw.dbsubsetter.db
 
-import java.util.NoSuchElementException
-
 import trw.dbsubsetter.config.{ConfigColumn, SchemaConfig}
 import trw.dbsubsetter.db.ColumnTypes.ColumnType
 
+import java.util.NoSuchElementException
+
 object SchemaInfoRetrieval {
   def getSchemaInfo(dbMetadata: DbMetadataQueryResult, schemaConfig: SchemaConfig): SchemaInfo = {
-    val includedTables =
+    val includedTables = {
       dbMetadata.tables
         .map { tableQueryRow =>
           val schema = Schema(tableQueryRow.schema)
           Table(schema, tableQueryRow.name)
         }
         .filterNot(schemaConfig.excludeTables)
+    }
 
-    val tablesByName =
+    val tablesByName = {
       includedTables
         .map(table => (table.schema.name, table.name) -> table)
         .toMap
+    }
 
-    val tablesWithAutoincrementMetadata =
+    val tablesWithAutoincrementMetadata = {
       includedTables
         .map { table =>
           val hasSqlServerAutoincrement =
@@ -33,6 +35,7 @@ object SchemaInfoRetrieval {
 
           TableWithAutoincrementMetadata(table, hasSqlServerAutoincrement)
         }
+    }
 
     val colsByTableAndName: Map[Table, Map[String, Column]] = {
       dbMetadata.columns
@@ -86,7 +89,7 @@ object SchemaInfoRetrieval {
       autodetectedPrimaryKeys ++ configuredPrimaryKeys
     }
 
-    val foreignKeysOrdered: Array[ForeignKey] = {
+    val foreignKeys: Iterable[ForeignKey] = {
       val configuredForeignKeys =
         schemaConfig.extraForeignKeys
           .flatMap { efk =>
@@ -106,64 +109,58 @@ object SchemaInfoRetrieval {
 
       val combinedForeignKeys = dbMetadata.foreignKeyColumns ++ configuredForeignKeys
 
-      val fksUnordered =
-        combinedForeignKeys
-          .filter(fk => tablesByName.contains((fk.fromSchema, fk.fromTable)))
-          .filter(fk => tablesByName.contains((fk.toSchema, fk.toTable)))
-          .groupBy(fkm => (fkm.fromSchema, fkm.fromTable, fkm.toSchema, fkm.toTable))
-          .map { case ((fromSchemaName, fromTableName, toSchemaName, toTableName), partialForeignKeys) =>
-            val fromTable = tablesByName(fromSchemaName, fromTableName)
-            val fromCols = partialForeignKeys.map { pfk => colsByTableAndName(fromTable)(pfk.fromColumn) }
-            val toTable = tablesByName(toSchemaName, toTableName)
-            // MySQL schema introspection has a bug where they don't properly capitalize column names of
-            // the `pointedTo` side of foreign keys.
-            //
-            // Doesn't seem to be remedied by &useInformationSchema=true in DB URL so that the `DatabaseMetaDataUsingInfoSchema` class is used
-            //
-            // This seems to be a bug at the MySQL layer, not at the JDBC Driver layer because the same
-            // issue is present in the command line program using the `show create table my_table` command
-            //
-            // This is a hacky workaround and could cause problems in a schema where the same column name
-            // is used twice in the same table with different capitalization. (This seems like it ought to be either impossible or rare though).
-            //
-            // A less hacky workaround would be to match by column ordinal rather than by name, but unfortunately that info
-            // is not included in the result of the query we make to get foreign keys.
-            lazy val mysqlWorkaround =
-              colsByTableAndName
-                .mapValues { nameToColMap =>
-                  nameToColMap
-                    .map { case (k, v) =>
-                      k.toLowerCase -> v
-                    }
-                }
-            val toCols = partialForeignKeys.map { pfk =>
-              try {
-                colsByTableAndName(toTable)(pfk.toColumn)
-              } catch {
-                case _: NoSuchElementException if dbMetadata.vendor == DbVendor.MySQL =>
-                  mysqlWorkaround(toTable)(pfk.toColumn)
-                case e: Throwable =>
-                  throw e
+      combinedForeignKeys
+        .filter(fk => tablesByName.contains((fk.fromSchema, fk.fromTable)))
+        .filter(fk => tablesByName.contains((fk.toSchema, fk.toTable)))
+        .groupBy(fkm => (fkm.fromSchema, fkm.fromTable, fkm.toSchema, fkm.toTable))
+        .map { case ((fromSchemaName, fromTableName, toSchemaName, toTableName), partialForeignKeys) =>
+          val fromTable = tablesByName(fromSchemaName, fromTableName)
+          val fromCols = partialForeignKeys.map { pfk => colsByTableAndName(fromTable)(pfk.fromColumn) }
+          val toTable = tablesByName(toSchemaName, toTableName)
+          // MySQL schema introspection has a bug where they don't properly capitalize column names of
+          // the `pointedTo` side of foreign keys.
+          //
+          // Doesn't seem to be remedied by &useInformationSchema=true in DB URL so that the `DatabaseMetaDataUsingInfoSchema` class is used
+          //
+          // This seems to be a bug at the MySQL layer, not at the JDBC Driver layer because the same
+          // issue is present in the command line program using the `show create table my_table` command
+          //
+          // This is a hacky workaround and could cause problems in a schema where the same column name
+          // is used twice in the same table with different capitalization. (This seems like it ought to be either impossible or rare though).
+          //
+          // A less hacky workaround would be to match by column ordinal rather than by name, but unfortunately that info
+          // is not included in the result of the query we make to get foreign keys.
+          lazy val mysqlWorkaround =
+            colsByTableAndName
+              .mapValues { nameToColMap =>
+                nameToColMap
+                  .map { case (k, v) =>
+                    k.toLowerCase -> v
+                  }
               }
+          val toCols = partialForeignKeys.map { pfk =>
+            try {
+              colsByTableAndName(toTable)(pfk.toColumn)
+            } catch {
+              case _: NoSuchElementException if dbMetadata.vendor == DbVendor.MySQL =>
+                mysqlWorkaround(toTable)(pfk.toColumn)
+              case e: Throwable =>
+                throw e
             }
-
-            val pointsToPk = pksByTable.get(toTable).fold(false)(pk => pk.columns == toCols)
-
-            new ForeignKey(fromCols, toCols, pointsToPk, 0)
           }
 
-      fksUnordered.toArray.zipWithIndex.map { case (fk, idx) =>
-        fk.setIndex(idx.toShort)
-        fk
-      }
+          val pointsToPk = pksByTable.get(toTable).fold(false)(pk => pk.columns == toCols)
+
+          new ForeignKey(fromCols, toCols, pointsToPk)
+        }
     }
 
     val fksFromTable: Map[Table, Vector[ForeignKey]] = {
-      foreignKeysOrdered.toVector.groupBy(_.fromTable).withDefaultValue(Vector.empty)
+      foreignKeys.toVector.groupBy(_.fromTable).withDefaultValue(Vector.empty)
     }
 
     val fksToTable: Map[Table, Vector[ForeignKey]] = {
-      foreignKeysOrdered.toVector.groupBy(_.toTable).withDefaultValue(Vector.empty)
+      foreignKeys.toVector.groupBy(_.toTable).withDefaultValue(Vector.empty)
     }
 
     val keyColumnsByTableOrdered: Map[Table, Vector[Column]] = {
@@ -193,7 +190,7 @@ object SchemaInfoRetrieval {
       keyColumnsByTableOrdered = keyColumnsByTableOrdered,
       dataColumnsByTableOrdered = allColumnsByTableOrdered,
       pksByTable = pksByTable,
-      fksOrdered = foreignKeysOrdered,
+      foreignKeys = foreignKeys.toVector,
       fksFromTable = fksFromTable,
       fksToTable = fksToTable
     )

--- a/src/main/scala/trw/dbsubsetter/db/Sql.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Sql.scala
@@ -3,7 +3,7 @@ package trw.dbsubsetter.db
 private[db] object Sql {
   def queryByFkSqlTemplates(sch: SchemaInfo): ForeignKeySqlTemplates = {
     val allCombos = for {
-      fk <- sch.fksOrdered
+      fk <- sch.foreignKeys
       table <- Set(fk.fromTable, fk.toTable)
     } yield (fk, table)
 

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -1,8 +1,8 @@
 package trw.dbsubsetter
 
-import java.sql.Connection
-
 import trw.dbsubsetter.db.ColumnTypes.ColumnType
+
+import java.sql.Connection
 
 package object db {
 
@@ -23,7 +23,7 @@ package object db {
       // All columns, even those uninvolved in a primary or foreign key
       val dataColumnsByTableOrdered: Map[Table, Vector[Column]],
       val pksByTable: Map[Table, PrimaryKey],
-      val fksOrdered: Array[ForeignKey],
+      val foreignKeys: Seq[ForeignKey],
       val fksFromTable: Map[Table, Vector[ForeignKey]],
       val fksToTable: Map[Table, Vector[ForeignKey]]
   )
@@ -52,16 +52,10 @@ package object db {
   class ForeignKey(
       val fromCols: Seq[Column],
       val toCols: Seq[Column],
-      val pointsToPk: Boolean,
-      var i: Short
+      val pointsToPk: Boolean
   ) {
     val fromTable: Table = fromCols.head.table
     val toTable: Table = toCols.head.table
-
-    // TODO Refactor to remove mutability
-    def setIndex(index: Short): Unit = {
-      i = index
-    }
   }
 
   // Primary keys can be multi-column. Therefore a single primary key value is a sequence of individual column values.

--- a/src/main/scala/trw/dbsubsetter/fkcalc/FkExtractor.scala
+++ b/src/main/scala/trw/dbsubsetter/fkcalc/FkExtractor.scala
@@ -4,7 +4,7 @@ import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, Keys, SchemaInfo}
 
 private[fkcalc] object FkExtractor {
   def fkExtractionFunctions(schemaInfo: SchemaInfo): Map[(ForeignKey, Boolean), Keys => ForeignKeyValue] = {
-    schemaInfo.fksOrdered.flatMap { foreignKey =>
+    schemaInfo.foreignKeys.flatMap { foreignKey =>
       val parentExtractionFunction: Keys => ForeignKeyValue =
         keys => keys.getValue(foreignKey, confusingTechDebt = false)
 

--- a/src/main/scala/trw/dbsubsetter/fktaskqueue/ChronicleQueueFkTaskWriter.scala
+++ b/src/main/scala/trw/dbsubsetter/fktaskqueue/ChronicleQueueFkTaskWriter.scala
@@ -5,7 +5,7 @@ import trw.dbsubsetter.chronicle.ChronicleQueueFunctions
 import trw.dbsubsetter.db.ColumnTypes.ColumnType
 import trw.dbsubsetter.db.ForeignKeyValue
 
-private[fktaskqueue] final class ChronicleQueueFkTaskWriter(fkOrdinal: Short, columnTypes: Seq[ColumnType]) {
+private[fktaskqueue] final class ChronicleQueueFkTaskWriter(fkOrdinal: Int, columnTypes: Seq[ColumnType]) {
   private[this] val valueWriter: (ValueOut, ForeignKeyValue) => Unit = {
     val singleColumnWriteFunctions: Seq[(ValueOut, Any) => WireOut] =
       columnTypes.map(ChronicleQueueFunctions.singleValueWrite)

--- a/src/main/scala/trw/dbsubsetter/fktaskqueue/ForeignKeyTaskQueue.scala
+++ b/src/main/scala/trw/dbsubsetter/fktaskqueue/ForeignKeyTaskQueue.scala
@@ -1,9 +1,9 @@
 package trw.dbsubsetter.fktaskqueue
 
-import java.nio.file.Path
-
 import trw.dbsubsetter.db.SchemaInfo
 import trw.dbsubsetter.fkcalc.ForeignKeyTask
+
+import java.nio.file.Path
 
 trait ForeignKeyTaskQueue {
   def enqueue(foreignKeyTask: ForeignKeyTask): Unit
@@ -14,7 +14,7 @@ trait ForeignKeyTaskQueue {
 
 object ForeignKeyTaskQueue {
   def from(storageDirectory: Path, schemaInfo: SchemaInfo): ForeignKeyTaskQueue = {
-    val base: ForeignKeyTaskQueue = new ForeignKeyTaskQueueImpl(storageDirectory, schemaInfo)
+    val base: ForeignKeyTaskQueue = new ForeignKeyTaskQueueImpl(storageDirectory, schemaInfo.foreignKeys)
     new ForeignKeyTaskQueueInstrumentedImpl(base)
   }
 }

--- a/src/main/scala/trw/dbsubsetter/fktaskqueue/ForeignKeyTaskQueueImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/fktaskqueue/ForeignKeyTaskQueueImpl.scala
@@ -3,7 +3,7 @@ package trw.dbsubsetter.fktaskqueue
 import net.openhft.chronicle.queue.impl.single.SingleChronicleQueue
 import net.openhft.chronicle.wire.WriteMarshallable
 import trw.dbsubsetter.chronicle.ChronicleQueueFactory
-import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue, SchemaInfo}
+import trw.dbsubsetter.db.{ForeignKey, ForeignKeyValue}
 import trw.dbsubsetter.fkcalc.{FetchChildrenTask, FetchParentTask, ForeignKeyTask}
 
 import java.nio.file.Path
@@ -11,52 +11,52 @@ import java.nio.file.Path
 /**
   * WARNING: this class is not threadsafe
   */
-private[fktaskqueue] final class ForeignKeyTaskQueueImpl(storageDirectory: Path, schemaInfo: SchemaInfo)
-    extends ForeignKeyTaskQueue {
+private[fktaskqueue] final class ForeignKeyTaskQueueImpl(dir: Path, fks: Seq[ForeignKey]) extends ForeignKeyTaskQueue {
 
   private[this] var queuedTaskCount: Long = 0L
 
-  private[this] val queue: SingleChronicleQueue = ChronicleQueueFactory.createQueue(storageDirectory)
+  private[this] val queue: SingleChronicleQueue = ChronicleQueueFactory.createQueue(dir)
 
   private[this] val appender = queue.acquireAppender()
 
   private[this] val tailer = queue.createTailer()
 
+  private[this] val foreignKeyLookup: Array[ForeignKey] = fks.toArray
+
+  private[this] val indexByForeignKey: Map[ForeignKey, Int] = foreignKeyLookup.zipWithIndex.toMap
+
   private[this] val childReaders =
-    schemaInfo.foreignKeys
-      .map { fk =>
-        new ChronicleQueueFkTaskReader(fk.fromCols.map(_.dataType))
-      }
+    foreignKeyLookup.map { fk =>
+      new ChronicleQueueFkTaskReader(fk.fromCols.map(_.dataType))
+    }
 
   private[this] val parentReaders =
-    schemaInfo.foreignKeys.map { fk =>
+    foreignKeyLookup.map { fk =>
       new ChronicleQueueFkTaskReader(fk.toCols.map(_.dataType))
     }
 
   private[this] val parentFkWriters =
-    schemaInfo.foreignKeys
-      .map { fk =>
-        new ChronicleQueueFkTaskWriter(fk.i, fk.toCols.map(_.dataType))
-      }
+    foreignKeyLookup.zipWithIndex.map { case (fk, i) =>
+      new ChronicleQueueFkTaskWriter(i, fk.toCols.map(_.dataType))
+    }
 
   private[this] val childFkWriters =
-    schemaInfo.foreignKeys
-      .map { fk =>
-        new ChronicleQueueFkTaskWriter(fk.i, fk.fromCols.map(_.dataType))
-      }
+    foreignKeyLookup.zipWithIndex.map { case (fk, i) =>
+      new ChronicleQueueFkTaskWriter(i, fk.fromCols.map(_.dataType))
+    }
 
   override def enqueue(foreignKeyTask: ForeignKeyTask): Unit = {
     this.synchronized {
       foreignKeyTask match {
         case FetchChildrenTask(fk, fkValue) =>
           write(
-            writer = childFkWriters(fk.i),
+            writer = childFkWriters(indexByForeignKey(fk)),
             fetchChildren = true,
             value = fkValue
           )
         case FetchParentTask(fk, fkValue) =>
           write(
-            writer = parentFkWriters(fk.i),
+            writer = parentFkWriters(indexByForeignKey(fk)),
             fetchChildren = false,
             value = fkValue
           )
@@ -89,7 +89,7 @@ private[fktaskqueue] final class ForeignKeyTaskQueueImpl(storageDirectory: Path,
 
         val fkValue: ForeignKeyValue = reader.read(in)
 
-        val foreignKey: ForeignKey = schemaInfo.foreignKeys(fkOrdinal)
+        val foreignKey: ForeignKey = foreignKeyLookup(fkOrdinal)
 
         val task: ForeignKeyTask =
           if (fetchChildren) {

--- a/src/test/scala/integration/ForeignKeyTaskQueueTest.scala
+++ b/src/test/scala/integration/ForeignKeyTaskQueueTest.scala
@@ -106,8 +106,7 @@ private[this] object ForeignKeyTaskQueueTest {
     new ForeignKey(
       fromCols = Vector(childFkColumn),
       toCols = Vector(parentPkColumn),
-      pointsToPk = true,
-      i = 0
+      pointsToPk = true
     )
 
   private val schemaInfo: SchemaInfo =

--- a/src/test/scala/integration/ForeignKeyTaskQueueTest.scala
+++ b/src/test/scala/integration/ForeignKeyTaskQueueTest.scala
@@ -1,11 +1,11 @@
 package integration
 
-import java.nio.file.{Files, Path}
-
 import org.scalatest.FunSuite
 import trw.dbsubsetter.db.{Column, ColumnTypes, ForeignKey, ForeignKeyValue, Schema, SchemaInfo, Table}
 import trw.dbsubsetter.fkcalc.{FetchParentTask, ForeignKeyTask}
 import trw.dbsubsetter.fktaskqueue.ForeignKeyTaskQueue
+
+import java.nio.file.{Files, Path}
 
 /*
  * TODO add more test cases covering various combinations of:
@@ -116,7 +116,7 @@ private[this] object ForeignKeyTaskQueueTest {
       keyColumnsByTableOrdered = Map.empty,
       dataColumnsByTableOrdered = Map.empty,
       pksByTable = Map.empty,
-      fksOrdered = Array(foreignKey),
+      foreignKeys = Array(foreignKey),
       fksFromTable = Map.empty,
       fksToTable = Map.empty
     )

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -28,7 +28,7 @@ class PkStoreWorkflowTest extends FunSuite {
         keyColumnsByTableOrdered = Map.empty,
         dataColumnsByTableOrdered = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(pkCol))),
-        fksOrdered = Array.empty,
+        foreignKeys = Array.empty,
         fksFromTable = Map.empty,
         fksToTable = Map.empty
       )
@@ -90,7 +90,7 @@ class PkStoreWorkflowTest extends FunSuite {
         keyColumnsByTableOrdered = Map.empty,
         dataColumnsByTableOrdered = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(primaryKeyColumn))),
-        fksOrdered = Array.empty,
+        foreignKeys = Array.empty,
         fksFromTable = Map.empty,
         fksToTable = Map.empty
       )

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -28,7 +28,7 @@ class PkStoreWorkflowTest extends FunSuite {
         keyColumnsByTableOrdered = Map.empty,
         dataColumnsByTableOrdered = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(pkCol))),
-        foreignKeys = Array.empty,
+        foreignKeys = Seq.empty,
         fksFromTable = Map.empty,
         fksToTable = Map.empty
       )
@@ -90,7 +90,7 @@ class PkStoreWorkflowTest extends FunSuite {
         keyColumnsByTableOrdered = Map.empty,
         dataColumnsByTableOrdered = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(primaryKeyColumn))),
-        foreignKeys = Array.empty,
+        foreignKeys = Seq.empty,
         fksFromTable = Map.empty,
         fksToTable = Map.empty
       )


### PR DESCRIPTION
Mutable index `i` is no longer an inherent attribute of a foreign key -- now it is created and encapsulated only in the places that need it.