### PR TITLE
Remove column ordinal positions

### DIFF
--- a/src/main/scala/trw/dbsubsetter/datacopy/DataCopierPostgresImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/datacopy/DataCopierPostgresImpl.scala
@@ -1,12 +1,11 @@
 package trw.dbsubsetter.datacopy
 
-import java.io.{PipedInputStream, PipedOutputStream}
-import java.util.UUID
-import java.util.concurrent.Executors
-
 import org.postgresql.copy.CopyManager
 import trw.dbsubsetter.db.{Constants, DbAccessFactory, SchemaInfo}
 
+import java.io.{PipedInputStream, PipedOutputStream}
+import java.util.UUID
+import java.util.concurrent.Executors
 import scala.concurrent.{ExecutionContext, Future}
 
 private[datacopy] final class DataCopierPostgresImpl(dbAccessFactory: DbAccessFactory, schemaInfo: SchemaInfo)
@@ -28,7 +27,7 @@ private[datacopy] final class DataCopierPostgresImpl(dbAccessFactory: DbAccessFa
 
     val allColumnNamesSql: String =
       schemaInfo
-        .dataColumnsByTableOrdered(task.table)
+        .dataColumnsByTable(task.table)
         .map(col => s""""${col.name}"""")
         .mkString(", ")
 

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -1,9 +1,8 @@
 package trw.dbsubsetter.db
 
-import java.util.NoSuchElementException
-
 import trw.dbsubsetter.config.{ConfigColumn, SchemaConfig}
-import trw.dbsubsetter.db.ColumnTypes.ColumnType
+
+import java.util.NoSuchElementException
 
 object SchemaInfoRetrieval {
   def getSchemaInfo(dbMetadata: DbMetadataQueryResult, schemaConfig: SchemaConfig): SchemaInfo = {
@@ -34,7 +33,7 @@ object SchemaInfoRetrieval {
           TableWithAutoincrementMetadata(table, hasSqlServerAutoincrement)
         }
 
-    val colsByTableAndName: Map[Table, Map[String, Column]] = {
+    val columnsByTable: Map[Table, Seq[Column]] = {
       dbMetadata.columns
         .filterNot { columnQueryRow =>
           val schema = Schema(columnQueryRow.schema)
@@ -45,22 +44,21 @@ object SchemaInfoRetrieval {
         .filter(c => tablesByName.contains((c.schema, c.table)))
         .groupBy(c => tablesByName(c.schema, c.table))
         .map { case (table, cols) =>
-          table -> cols.zipWithIndex.map { case (c, i) =>
-            val columnType: ColumnType = ColumnTypes.fromRawInfo(c.jdbcType, c.typeName, dbMetadata.vendor)
-            val column: Column = new Column(
+          table -> cols.map { col =>
+            new Column(
               table = table,
-              name = c.name,
-              keyOrdinalPosition = -1, // Placeholder value that will be mutated (corrected) later
-              dataOrdinalPosition = i,
-              dataType = columnType
+              name = col.name,
+              dataType = ColumnTypes.fromRawInfo(col.jdbcType, col.typeName, dbMetadata.vendor)
             )
-            c.name -> column
-          }.toMap
+          }
         }
     }
 
-    val allColumnsByTableOrdered: Map[Table, Vector[Column]] = {
-      colsByTableAndName.map { case (table, map) => table -> map.values.toVector.sortBy(_.dataOrdinalPosition) }
+    val colsByTableAndName: Map[Table, Map[String, Column]] = {
+      columnsByTable
+        .map { case (table, columns) =>
+          table -> columns.map(col => col.name -> col).toMap
+        }
     }
 
     val pksByTable: Map[Table, PrimaryKey] = {
@@ -70,8 +68,8 @@ object SchemaInfoRetrieval {
           .groupBy(pk => tablesByName(pk.schema, pk.table))
           .map { case (table, singleTablePrimaryKeyMetadataRows) =>
             val columnNames = singleTablePrimaryKeyMetadataRows.map(_.column).toSet
-            val orderedColumns = allColumnsByTableOrdered(table).filter(c => columnNames.contains(c.name))
-            table -> new PrimaryKey(orderedColumns)
+            val columns = columnsByTable(table).filter(c => columnNames.contains(c.name))
+            table -> new PrimaryKey(columns)
           }
 
       val configuredPrimaryKeys =
@@ -79,8 +77,8 @@ object SchemaInfoRetrieval {
           .map { cmdLinePrimaryKey =>
             val table = cmdLinePrimaryKey.table
             val columnNames = cmdLinePrimaryKey.columns.map(_.name).toSet
-            val orderedColumns = allColumnsByTableOrdered(table).filter(c => columnNames.contains(c.name))
-            table -> new PrimaryKey(orderedColumns)
+            val columns = columnsByTable(table).filter(c => columnNames.contains(c.name))
+            table -> new PrimaryKey(columns)
           }
 
       autodetectedPrimaryKeys ++ configuredPrimaryKeys
@@ -166,32 +164,23 @@ object SchemaInfoRetrieval {
       foreignKeysOrdered.toVector.groupBy(_.toTable).withDefaultValue(Vector.empty)
     }
 
-    val keyColumnsByTableOrdered: Map[Table, Vector[Column]] = {
-      allColumnsByTableOrdered.map { case (table, allColumns) =>
+    val keyColumnsByTable: Map[Table, Seq[Column]] = {
+      tablesByName.map { case (_, table) =>
         val primaryKey: PrimaryKey = pksByTable(table)
         val foreignKeysFromTable: Seq[ForeignKey] = fksFromTable(table)
         val foreignKeysToTable: Seq[ForeignKey] = fksToTable(table)
-
-        def isKeyColumn(col: Column): Boolean = {
-          primaryKey.columns.contains(col) ||
-            foreignKeysFromTable.exists(_.fromCols.contains(col)) ||
-            foreignKeysToTable.exists(_.toCols.contains(col))
-        }
-
-        val keyColumns: Vector[Column] = allColumns.filter(isKeyColumn)
-
-        keyColumns.zipWithIndex.foreach { case (keyColumn, i) =>
-          keyColumn.keyOrdinalPosition = i
-        }
-
-        table -> keyColumns
+        val allColumns: Set[Column] =
+          primaryKey.columns.toSet ++
+            foreignKeysFromTable.flatMap(_.fromCols).toSet ++
+            foreignKeysToTable.flatMap(_.toCols).toSet
+        table -> allColumns.toSeq
       }
     }
 
     new SchemaInfo(
       tables = tablesWithAutoincrementMetadata,
-      keyColumnsByTableOrdered = keyColumnsByTableOrdered,
-      dataColumnsByTableOrdered = allColumnsByTableOrdered,
+      keyColumnsByTable = keyColumnsByTable,
+      dataColumnsByTable = columnsByTable,
       pksByTable = pksByTable,
       fksOrdered = foreignKeysOrdered,
       fksFromTable = fksFromTable,

--- a/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
+++ b/src/main/scala/trw/dbsubsetter/db/SchemaInfoRetrieval.scala
@@ -166,14 +166,11 @@ object SchemaInfoRetrieval {
 
     val keyColumnsByTable: Map[Table, Seq[Column]] = {
       tablesByName.map { case (_, table) =>
-        val primaryKey: PrimaryKey = pksByTable(table)
-        val foreignKeysFromTable: Seq[ForeignKey] = fksFromTable(table)
-        val foreignKeysToTable: Seq[ForeignKey] = fksToTable(table)
-        val allColumns: Set[Column] =
-          primaryKey.columns.toSet ++
-            foreignKeysFromTable.flatMap(_.fromCols).toSet ++
-            foreignKeysToTable.flatMap(_.toCols).toSet
-        table -> allColumns.toSeq
+        val allColumns: Seq[Column] =
+          pksByTable(table).columns ++
+            fksFromTable(table).flatMap(_.fromCols) ++
+            fksToTable(table).flatMap(_.toCols)
+        table -> allColumns.distinct
       }
     }
 

--- a/src/main/scala/trw/dbsubsetter/db/Sql.scala
+++ b/src/main/scala/trw/dbsubsetter/db/Sql.scala
@@ -20,7 +20,7 @@ private[db] object Sql {
           makeSimpleWhereClause(whereClauseColumns)
 
         val selectColumns: Seq[Column] =
-          sch.keyColumnsByTableOrdered(table)
+          sch.keyColumnsByTable(table)
 
         (fk, table) -> makeQueryString(table, selectColumns, whereClause)
       }.toMap
@@ -33,7 +33,7 @@ private[db] object Sql {
       sch.pksByTable.flatMap { case (table, primaryKey) =>
         Constants.dataCopyBatchSizes.map(batchSize => {
           val whereClause: String = makeCompositeWhereClause(primaryKey.columns, batchSize)
-          val selectColumns: Seq[Column] = sch.dataColumnsByTableOrdered(table)
+          val selectColumns: Seq[Column] = sch.dataColumnsByTable(table)
           (table, batchSize) -> makeQueryString(table, selectColumns, whereClause)
         })
       }
@@ -44,7 +44,7 @@ private[db] object Sql {
   def insertSqlTemplates(sch: SchemaInfo): Map[Table, SqlQuery] = {
     sch.tables.map { case TableWithAutoincrementMetadata(table, hasSqlServerAutoIncrement) =>
       val cols =
-        sch.dataColumnsByTableOrdered(table)
+        sch.dataColumnsByTable(table)
 
       val sqlString =
         s"""insert into ${quote(table)}

--- a/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/mapper/JdbcResultConverterImpl.scala
@@ -1,21 +1,20 @@
 package trw.dbsubsetter.db.impl.mapper
 
-import java.sql.ResultSet
-
 import trw.dbsubsetter.db.{Column, Keys, Row, SchemaInfo, Table}
 
+import java.sql.ResultSet
 import scala.collection.mutable.ArrayBuffer
 
 private[db] class JdbcResultConverterImpl(schemaInfo: SchemaInfo) extends JdbcResultConverter {
 
   def convertToRows(jdbcResultSet: ResultSet, table: Table): Vector[Row] = {
-    val cols: Seq[Column] = schemaInfo.dataColumnsByTableOrdered(table)
+    val cols: Seq[Column] = schemaInfo.dataColumnsByTable(table)
     val multipleRowsRawData = extractMultiRowRawData(jdbcResultSet, cols.size)
     multipleRowsRawData.map(singleRowRawData => new Row(singleRowRawData)).toVector
   }
 
-  override def convertToKeys(jdbcResultSet: ResultSet, table: Table): Vector[Keys] = {
-    val cols: Seq[Column] = schemaInfo.keyColumnsByTableOrdered(table)
+  override def convertToKeys(jdbcResultSet: ResultSet, table: Table): Seq[Keys] = {
+    val cols: Seq[Column] = schemaInfo.keyColumnsByTable(table)
     val multipleRowsRawData = extractMultiRowRawData(jdbcResultSet, cols.size)
     multipleRowsRawData.map(singleRowRawData => new Keys(singleRowRawData)).toVector
   }

--- a/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
+++ b/src/main/scala/trw/dbsubsetter/db/impl/origin/OriginDbAccessImpl.scala
@@ -1,10 +1,10 @@
 package trw.dbsubsetter.db.impl.origin
 
-import java.sql.PreparedStatement
-
 import trw.dbsubsetter.db._
 import trw.dbsubsetter.db.impl.ConnectionFactory
 import trw.dbsubsetter.db.impl.mapper.JdbcResultConverter
+
+import java.sql.PreparedStatement
 
 private[db] class OriginDbAccessImpl(
     connStr: String,
@@ -54,7 +54,7 @@ private[db] class OriginDbAccessImpl(
   }
 
   override def getRowsFromWhereClause(table: Table, whereClause: String): Vector[Keys] = {
-    val selectColumns = schemaInfo.keyColumnsByTableOrdered(table)
+    val selectColumns = schemaInfo.keyColumnsByTable(table)
     val sqlString = Sql.makeQueryString(table, selectColumns, whereClause)
     val jdbcResult = conn.createStatement().executeQuery(sqlString.value)
     mapper.convertToKeys(jdbcResult, table)

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -65,19 +65,19 @@ package object db {
   }
 
   // Represents a single row from the origin database including all columns
-  class Row(val data: Array[Any])
+  class Row(val data: Map[Column, Any])
 
   // Represents a single row from the origin database including only primary and foreign key columns
-  class Keys(data: Map[String, Any]) {
+  class Keys(data: Map[Column, Any]) {
 
     def getValue(pk: PrimaryKey): PrimaryKeyValue = {
-      val columnValues: Seq[Any] = pk.columns.map(_.name).map(data)
+      val columnValues: Seq[Any] = pk.columns.map(data)
       new PrimaryKeyValue(columnValues)
     }
 
     def getValue(fk: ForeignKey, confusingTechDebt: Boolean): ForeignKeyValue = {
       val columns: Seq[Column] = if (confusingTechDebt) fk.toCols else fk.fromCols
-      val columnValues: Seq[Any] = columns.map(_.name).map(data)
+      val columnValues: Seq[Any] = columns.map(data)
       new ForeignKeyValue(columnValues)
     }
   }

--- a/src/main/scala/trw/dbsubsetter/db/package.scala
+++ b/src/main/scala/trw/dbsubsetter/db/package.scala
@@ -1,8 +1,8 @@
 package trw.dbsubsetter
 
-import java.sql.Connection
-
 import trw.dbsubsetter.db.ColumnTypes.ColumnType
+
+import java.sql.Connection
 
 package object db {
 
@@ -19,9 +19,9 @@ package object db {
   class SchemaInfo(
       val tables: Seq[TableWithAutoincrementMetadata],
       // Only those columns involved in a primary or foreign key
-      val keyColumnsByTableOrdered: Map[Table, Vector[Column]],
+      val keyColumnsByTable: Map[Table, Seq[Column]],
       // All columns, even those uninvolved in a primary or foreign key
-      val dataColumnsByTableOrdered: Map[Table, Vector[Column]],
+      val dataColumnsByTable: Map[Table, Seq[Column]],
       val pksByTable: Map[Table, PrimaryKey],
       val fksOrdered: Array[ForeignKey],
       val fksFromTable: Map[Table, Vector[ForeignKey]],
@@ -36,14 +36,6 @@ package object db {
   class Column(
       val table: Table,
       val name: String,
-      /*
-       * The 0-indexed location of this column in query results where only primary and foreign key columns are included
-       * -1 if this column is not part of a primary or foreign key, as this column would not be included in that query.
-       * TODO make this immutable
-       */
-      var keyOrdinalPosition: Int,
-      // The 0-indexed location of this column in query results where all columns are included
-      val dataOrdinalPosition: Int,
       val dataType: ColumnType
   )
 
@@ -76,20 +68,18 @@ package object db {
   class Row(val data: Array[Any])
 
   // Represents a single row from the origin database including only primary and foreign key columns
-  class Keys(data: Array[Any]) {
+  class Keys(data: Map[String, Any]) {
 
     def getValue(pk: PrimaryKey): PrimaryKeyValue = {
-      val individualColumnValues: Seq[Any] = pk.columns.map(_.keyOrdinalPosition).map(data)
-      new PrimaryKeyValue(individualColumnValues)
+      val columnValues: Seq[Any] = pk.columns.map(_.name).map(data)
+      new PrimaryKeyValue(columnValues)
     }
 
     def getValue(fk: ForeignKey, confusingTechDebt: Boolean): ForeignKeyValue = {
       val columns: Seq[Column] = if (confusingTechDebt) fk.toCols else fk.fromCols
-      val individualColumnOrdinals: Seq[Int] = columns.map(_.keyOrdinalPosition)
-      val individualColumnValues: Seq[Any] = individualColumnOrdinals.map(data)
-      new ForeignKeyValue(individualColumnValues)
+      val columnValues: Seq[Any] = columns.map(_.name).map(data)
+      new ForeignKeyValue(columnValues)
     }
-
   }
 
   implicit class VendorAwareJdbcConnection(private val conn: Connection) {

--- a/src/test/scala/integration/ForeignKeyTaskQueueTest.scala
+++ b/src/test/scala/integration/ForeignKeyTaskQueueTest.scala
@@ -82,8 +82,6 @@ private[this] object ForeignKeyTaskQueueTest {
     new Column(
       table = parentTable,
       name = "id",
-      keyOrdinalPosition = 4,
-      dataOrdinalPosition = -1, // n/a
       ColumnTypes.Long
     )
 
@@ -97,8 +95,6 @@ private[this] object ForeignKeyTaskQueueTest {
     new Column(
       table = childTable,
       name = "parentId",
-      keyOrdinalPosition = 7,
-      dataOrdinalPosition = -1, // n/a
       ColumnTypes.Long
     )
 

--- a/src/test/scala/integration/ForeignKeyTaskQueueTest.scala
+++ b/src/test/scala/integration/ForeignKeyTaskQueueTest.scala
@@ -1,11 +1,11 @@
 package integration
 
-import java.nio.file.{Files, Path}
-
 import org.scalatest.FunSuite
 import trw.dbsubsetter.db.{Column, ColumnTypes, ForeignKey, ForeignKeyValue, Schema, SchemaInfo, Table}
 import trw.dbsubsetter.fkcalc.{FetchParentTask, ForeignKeyTask}
 import trw.dbsubsetter.fktaskqueue.ForeignKeyTaskQueue
+
+import java.nio.file.{Files, Path}
 
 /*
  * TODO add more test cases covering various combinations of:
@@ -113,8 +113,8 @@ private[this] object ForeignKeyTaskQueueTest {
   private val schemaInfo: SchemaInfo =
     new SchemaInfo(
       tables = Seq.empty,
-      keyColumnsByTableOrdered = Map.empty,
-      dataColumnsByTableOrdered = Map.empty,
+      keyColumnsByTable = Map.empty,
+      dataColumnsByTable = Map.empty,
       pksByTable = Map.empty,
       fksOrdered = Array(foreignKey),
       fksFromTable = Map.empty,

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -17,8 +17,6 @@ class PkStoreWorkflowTest extends FunSuite {
       new Column(
         table = table,
         name = null,
-        keyOrdinalPosition = 0,
-        dataOrdinalPosition = -1, // n/a
         dataType = null
       )
 
@@ -38,7 +36,7 @@ class PkStoreWorkflowTest extends FunSuite {
 
     val fkValue: String = "fkValue"
 
-    val singleRowKeys: Keys = new Keys(Array(fkValue))
+    val singleRowKeys: Keys = new Keys(Map(pkCol -> fkValue))
 
     val multiRowKeys: Vector[Keys] = Vector(singleRowKeys)
 
@@ -79,8 +77,6 @@ class PkStoreWorkflowTest extends FunSuite {
       new Column(
         table = table,
         name = null,
-        keyOrdinalPosition = 0,
-        dataOrdinalPosition = -1, // n/a
         dataType = null
       )
 
@@ -99,7 +95,7 @@ class PkStoreWorkflowTest extends FunSuite {
       PkStoreWorkflow.from(schemaInfo)
 
     val fkValue: String = "fkValue"
-    val singleRowKeys: Keys = new Keys(Array(fkValue))
+    val singleRowKeys: Keys = new Keys(Map(primaryKeyColumn -> fkValue))
     val multiRowKeys: Vector[Keys] = Vector(singleRowKeys)
 
     // Add the PK to the pkStore, noting that we have NOT yet fetched children

--- a/src/test/scala/unit/PkStoreWorkflowTest.scala
+++ b/src/test/scala/unit/PkStoreWorkflowTest.scala
@@ -25,8 +25,8 @@ class PkStoreWorkflowTest extends FunSuite {
     val schemaInfo: SchemaInfo =
       new SchemaInfo(
         tables = Seq.empty,
-        keyColumnsByTableOrdered = Map.empty,
-        dataColumnsByTableOrdered = Map.empty,
+        keyColumnsByTable = Map.empty,
+        dataColumnsByTable = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(pkCol))),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,
@@ -87,8 +87,8 @@ class PkStoreWorkflowTest extends FunSuite {
     val schemaInfo: SchemaInfo =
       new SchemaInfo(
         tables = Seq.empty,
-        keyColumnsByTableOrdered = Map.empty,
-        dataColumnsByTableOrdered = Map.empty,
+        keyColumnsByTable = Map.empty,
+        dataColumnsByTable = Map.empty,
         pksByTable = Map(table -> new PrimaryKey(Seq(primaryKeyColumn))),
         fksOrdered = Array.empty,
         fksFromTable = Map.empty,


### PR DESCRIPTION
Given a JDBC ResultSet, extract data by the column name rather than column ordinal. Given a row of data, reference the column values by column rather than by column ordinal.